### PR TITLE
Refactor/displayed

### DIFF
--- a/app/controllers/api/v1/product_actions_controller.rb
+++ b/app/controllers/api/v1/product_actions_controller.rb
@@ -1,28 +1,20 @@
 class Api::V1::ProductActionsController < Api::V1::BaseController
   def create
-    if permitted_params[:action_type] == 'display'
-      respond_with mark_displayed
-    else
-      puts 'Pendiente para like'
-    end
-  end
-
-  private
-
-  def mark_displayed
-    receiver_id = set_receiver_id
-    ProductAction.create!(
+    product_action = ProductAction.create!(
       receiver_id: receiver_id,
       product_id: permitted_params[:product_id],
       action_type: permitted_params[:action_type]
     )
+    respond_with product_action
   end
+
+  private
 
   def permitted_params
     params.permit(:product_id, :action_type)
   end
 
-  def set_receiver_id
+  def receiver_id
     cookies[:receiver_id]
   end
 end

--- a/app/controllers/api/v1/product_actions_controller.rb
+++ b/app/controllers/api/v1/product_actions_controller.rb
@@ -1,25 +1,25 @@
 class Api::V1::ProductActionsController < Api::V1::BaseController
   def create
-    mark_displayed
+    if permitted_params[:action_type] == 'display'
+      respond_with mark_displayed
+    else
+      puts 'Pendiente para like'
+    end
   end
 
   private
 
   def mark_displayed
     receiver_id = set_receiver_id
-    ActiveRecord::Base.transaction do
-      permitted_params[:products].each do |_key, value|
-        ProductAction.create!(
-          receiver_id: receiver_id,
-          product_id: value[:id],
-          action_type: 0
-        )
-      end
-    end
+    ProductAction.create!(
+      receiver_id: receiver_id,
+      product_id: permitted_params[:product_id],
+      action_type: permitted_params[:action_type]
+    )
   end
 
   def permitted_params
-    params.permit(products: {})
+    params.permit(:product_id, :action_type)
   end
 
   def set_receiver_id

--- a/app/controllers/api/v1/product_actions_controller.rb
+++ b/app/controllers/api/v1/product_actions_controller.rb
@@ -11,7 +11,7 @@ class Api::V1::ProductActionsController < Api::V1::BaseController
   private
 
   def permitted_params
-    params.permit(:product_id, :action_type)
+    params.require(:product_action).permit(:product_id, :action_type)
   end
 
   def receiver_id

--- a/app/javascript/src/api/products.js
+++ b/app/javascript/src/api/products.js
@@ -9,13 +9,16 @@ export default {
       url: path,
     });
   },
-  markDisplay(products) {
+  markDisplayed(payload) {
     const path = '/api/v1/product_actions';
 
     return api({
       method: 'post',
       url: path,
-      data: { products },
+      data: { 
+        product_id: payload,
+        action_type: 'display',
+      },
     });
   },
 };

--- a/app/javascript/src/components/product.vue
+++ b/app/javascript/src/components/product.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="home-product-container">
-    {{ markDisplayed(product.id) }}
     <div class="home-product">
       <div class="home-product__image-wrapper">
         <img
@@ -45,10 +44,8 @@ export default {
       return value.toUpperCase();
     },
   },
-  methods: {
-    markDisplayed(payload) {
-      this.$store.dispatch('markDisplayed', payload);
-    }
+  mounted() {
+    this.$store.dispatch('markDisplayed', this.product.id);
   },
 };
 </script>

--- a/app/javascript/src/components/product.vue
+++ b/app/javascript/src/components/product.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="home-product-container">
+    {{ markDisplayed(product.id) }}
     <div class="home-product">
       <div class="home-product__image-wrapper">
         <img
@@ -43,6 +44,11 @@ export default {
     toUpper(value) {
       return value.toUpperCase();
     },
+  },
+  methods: {
+    markDisplayed(payload) {
+      this.$store.dispatch('markDisplayed', payload);
+    }
   },
 };
 </script>

--- a/app/javascript/src/store/index.js
+++ b/app/javascript/src/store/index.js
@@ -25,9 +25,11 @@ const store = new Vuex.Store({
           return acc;
         }, {});
         context.commit('setProducts', products);
-        productsApi.markDisplay(products);
       });
     },
+    markDisplayed: (context, payload) => {
+      productsApi.markDisplayed(payload)
+    }
   },
   getters: {
     productsArray: state => (

--- a/app/serializers/product_action_serializer.rb
+++ b/app/serializers/product_action_serializer.rb
@@ -1,0 +1,5 @@
+class ProductActionSerializer < ActiveModel::Serializer
+  include Rails.application.routes.url_helpers
+
+  attributes :id, :product_id, :receiver_id, :action_type
+end

--- a/spec/controllers/api/v1/product_actions_controller_spec.rb
+++ b/spec/controllers/api/v1/product_actions_controller_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ProductActionsController, type: :controller do
+  describe 'POST #create' do
+    let(:receiver) { create(:receiver) }
+    let(:product) { create(:product) }
+    let(:product_action_params) do
+      { product_action: {
+        product_id: product.id,
+        action_type: 'display'
+      } }
+    end
+
+    before do
+      request.cookies['receiver_id'] = receiver.id
+    end
+
+    it 'returns http success' do
+      post :create, params: product_action_params, as: :json
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
- Cada vez que se renderea un producto, llamará a un método `markDisplayed` en el componente `product.vue` con el ID del producto como `payload`, y este a su vez llamará a la acción `markDisplayed` de `store.js` (vuex). Este último es el que mandará un request al endpoint en rails. 
- El JSON generado ahora solo contiene el ID del producto y el tipo de acción que corresponde.
- El controller para `ProductActions` del endpoint ahora responde al request con el objeto una vez creado.

EDITS:

- Se agregó un Product Action serializer y spec file.
- Cambió la forma en que se le avisa a `store` que haga el request `POST` al endpoint (desde un lifecycle hook en lugar de un método).
- El método `create` del endpoint ahora recibe cualquier tipo de `product action`.
