### PR TITLE
feat(product-click): register click action in product_actions table

### DIFF
--- a/app/javascript/src/api/products.js
+++ b/app/javascript/src/api/products.js
@@ -22,6 +22,18 @@ export default {
       },
     });
   },
+  markClicked(payload) {
+    const path = '/api/v1/product_actions';
+
+    return api({
+      method: 'post',
+      url: path,
+      data: {
+        product_id: payload,
+        action_type: 'click',
+      },
+    });
+  },
   markLiked(payload) {
     const path = '/api/v1/product_actions';
 

--- a/app/javascript/src/components/product.vue
+++ b/app/javascript/src/components/product.vue
@@ -5,7 +5,7 @@
     <div class="home-product">
       <div
         class="home-product__image-wrapper"
-        @click="openNewTab"
+        @click="clickAction"
       >
         <div class="image-container">
           <img
@@ -33,7 +33,7 @@
       </div>
       <div
         class="home-product__title"
-        @click="openNewTab"
+        @click="clickAction"
       >
         {{ product.name }}
       </div>
@@ -68,6 +68,7 @@ export default {
     ...mapActions([
       'markLiked',
       'markDisplayed',
+      'markClicked',
     ]),
     setLikeStatus() {
       if (this.liked) {
@@ -78,7 +79,8 @@ export default {
       }
       this.onLike(this.liked);
     },
-    openNewTab() {
+    clickAction() {
+      this.markClicked(this.product.id);
       window.open(this.product.link, '_blank');
     },
   },

--- a/app/javascript/src/store/index.js
+++ b/app/javascript/src/store/index.js
@@ -61,6 +61,9 @@ const store = new Vuex.Store({
     markLiked: (context, payload) => {
       productsApi.markLiked(payload);
     },
+    markClicked: (context, payload) => {
+      productsApi.markClicked(payload);
+    },
     moreProducts: context => new Promise((resolve, reject) => {
       const params = [
         NUMBER_OF_PRODUCTS,

--- a/app/models/product_action.rb
+++ b/app/models/product_action.rb
@@ -1,7 +1,7 @@
 class ProductAction < ApplicationRecord
   belongs_to :product
   belongs_to :receiver
-  enum action_type: { display: 0, like: 1, dislike: 2 }
+  enum action_type: { display: 0, like: 1, dislike: 2, click: 3 }
 
   validates :action_type, presence: true
 end


### PR DESCRIPTION
Agrega la funcionalidad para registrar los clicks en la tabla de product_actions