### PR TITLE
Feat/reduce store balance on promoted click

### DIFF
--- a/app/admin/store_deposits.rb
+++ b/app/admin/store_deposits.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Deposit do
   end
 
   form do |f|
-    f.object.organization ||= Organization.find_by(name: 'Platanus')
+    f.object.organization ||= Organization.platanus
     f.object.deposit_time = Date.current
 
     f.inputs do

--- a/app/jobs/deposit_accounter_job.rb
+++ b/app/jobs/deposit_accounter_job.rb
@@ -1,0 +1,7 @@
+class DepositAccounterJob < ApplicationJob
+  queue_as :default
+
+  def perform(deposit)
+    DepositAccounter.for(deposit: deposit)
+  end
+end

--- a/app/jobs/promoted_click_accounter_job.rb
+++ b/app/jobs/promoted_click_accounter_job.rb
@@ -1,0 +1,11 @@
+class PromotedClickAccounterJob < ApplicationJob
+  queue_as :default
+
+  def perform(product_action, organization)
+    PromotedClickAccounter.for(
+      organization: organization,
+      store: product_action.store,
+      product_action: product_action
+    )
+  end
+end

--- a/app/models/deposit.rb
+++ b/app/models/deposit.rb
@@ -1,18 +1,11 @@
 class Deposit < ApplicationRecord
+  include PowerTypes::Observable
   include LedgerizerDocument
 
   belongs_to :store
   belongs_to :organization
 
   validates :amount, presence: true, numericality: { greater_than_or_equal_to: 0 }
-
-  after_save :execute_store_deposit
-
-  private
-
-  def execute_store_deposit
-    DepositAccounter.for(deposit: self)
-  end
 end
 
 # == Schema Information

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -5,6 +5,10 @@ class Organization < ApplicationRecord
   has_many :deposits, dependent: :destroy
 
   validates :name, presence: true, length: { minimum: 3, maximum: 20 }
+
+  def self.platanus
+    find_by(name: 'Platanus')
+  end
 end
 
 # == Schema Information

--- a/app/models/product_action.rb
+++ b/app/models/product_action.rb
@@ -1,11 +1,14 @@
 class ProductAction < ApplicationRecord
+  include PowerTypes::Observable
   include LedgerizerDocument
 
   belongs_to :product
   belongs_to :receiver
-  enum action_type: { display: 0, like: 1, dislike: 2, click: 3 }
+  enum action_type: { display: 0, like: 1, dislike: 2, click: 3, promoted_click: 4 }
 
   validates :action_type, presence: true
+
+  delegate :store, to: :product
 end
 
 # == Schema Information

--- a/app/observers/deposit_observer.rb
+++ b/app/observers/deposit_observer.rb
@@ -1,0 +1,7 @@
+class DepositObserver < PowerTypes::Observer
+  after_save :execute_deposit_accounter
+
+  def execute_deposit_accounter
+    DepositAccounterJob.perform_later(object)
+  end
+end

--- a/app/observers/product_action_observer.rb
+++ b/app/observers/product_action_observer.rb
@@ -1,0 +1,10 @@
+class ProductActionObserver < PowerTypes::Observer
+  after_save :execute_promoted_click_accounter
+
+  def execute_promoted_click_accounter
+    if object&.promoted_click?
+      organization = Organization.find_by(name: 'Platanus')
+      PromotedClickAccounterJob.perform_later(object, organization)
+    end
+  end
+end

--- a/app/observers/product_action_observer.rb
+++ b/app/observers/product_action_observer.rb
@@ -3,7 +3,7 @@ class ProductActionObserver < PowerTypes::Observer
 
   def execute_promoted_click_accounter
     if object&.promoted_click?
-      organization = Organization.find_by(name: 'Platanus')
+      organization = Organization.platanus
       PromotedClickAccounterJob.perform_later(object, organization)
     end
   end

--- a/spec/jobs/deposit_accounter_job_spec.rb
+++ b/spec/jobs/deposit_accounter_job_spec.rb
@@ -1,0 +1,14 @@
+describe DepositAccounterJob do
+  let(:deposit) { create :deposit }
+  let(:perform) { described_class.perform_now(deposit) }
+
+  before { allow(DepositAccounter).to receive(:for) }
+
+  it 'calls DepositAccounter with that deposit' do
+    perform
+
+    expect(DepositAccounter).to(
+      have_received(:for).with(deposit: deposit)
+    )
+  end
+end

--- a/spec/jobs/promoted_click_accounter_job_spec.rb
+++ b/spec/jobs/promoted_click_accounter_job_spec.rb
@@ -1,0 +1,19 @@
+describe PromotedClickAccounterJob do
+  let(:product_action) { create :product_action }
+  let(:organization) { create :organization }
+  let(:perform) { described_class.perform_now(product_action, organization) }
+
+  before { allow(PromotedClickAccounter).to receive(:for) }
+
+  it 'calls PromotedClickAccounter with that product_action and organization' do
+    perform
+
+    expect(PromotedClickAccounter).to(
+      have_received(:for).with(
+        product_action: product_action,
+        organization: organization,
+        store: product_action.store
+      )
+    )
+  end
+end

--- a/spec/observers/deposit_observer_spec.rb
+++ b/spec/observers/deposit_observer_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe DepositObserver do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/observers/deposit_observer_spec.rb
+++ b/spec/observers/deposit_observer_spec.rb
@@ -1,5 +1,17 @@
 require 'rails_helper'
 
 describe DepositObserver do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include ActiveJob::TestHelper
+  subject(:deposit) { create :deposit }
+
+  def trigger(type, event)
+    described_class.trigger(type, event, deposit)
+  end
+
+  describe 'after save' do
+    it 'enqueues DepositAccounterJob if deposit is created' do
+      trigger :after, :save
+      expect(DepositAccounterJob).to have_been_enqueued.with(deposit)
+    end
+  end
 end

--- a/spec/observers/product_action_observer_spec.rb
+++ b/spec/observers/product_action_observer_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe ProductActionObserver do
+  include ActiveJob::TestHelper
+  subject(:product_action) { create :product_action, action_type: action_type }
+
+  let(:action_type) { "click" }
+
+  def trigger(type, event)
+    described_class.trigger(type, event, product_action)
+  end
+
+  describe 'after save' do
+    it 'doesnt enqueue PromotedClickAccounterJob if action is not promoted_click' do
+      trigger :after, :save
+      expect(PromotedClickAccounterJob).to have_been_enqueued.exactly(0).times
+    end
+
+    context "with action type promoted_click" do
+      let(:action_type) { "promoted_click" }
+
+      it 'enqueues PromotedClickAccounterJob' do
+        organization = create :organization
+        trigger :after, :save
+        expect(PromotedClickAccounterJob).to have_been_enqueued.with(product_action, organization)
+      end
+    end
+  end
+end

--- a/spec/support/observer.rb
+++ b/spec/support/observer.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before do
+    PowerTypes::Observable.observable_disabled = true
+  end
+end


### PR DESCRIPTION
* Se agrega el observador que ejecuta el job, el cual a su vez ejecuta el command para descontar el saldo de la tienda al haberse creado un "product_action" con el tipo "promoted_click".
* Se aprovecha de hacer un refactor en cómo se hacían los depósitos, se pasa del callback (after_save) al mismo sistema de los promoted_click. El observador, que ejecuta el job que ejecuta el command.
* Se crean los respectivos tests para los observers y los jobs.