### PR TITLE
Feat/new field has balance store

### DIFF
--- a/app/commands/deposit_accounter.rb
+++ b/app/commands/deposit_accounter.rb
@@ -11,5 +11,6 @@ class DepositAccounter < PowerTypes::Command.new(:deposit)
       credit(account: :available_store_funds, accountable: @deposit.store, amount: money_amount)
       debit(account: :bank_account, accountable: @deposit.organization, amount: money_amount)
     end
+    @deposit.store.update_has_enough_balance
   end
 end

--- a/app/commands/promoted_click_accounter.rb
+++ b/app/commands/promoted_click_accounter.rb
@@ -11,5 +11,6 @@ class PromotedClickAccounter < PowerTypes::Command.new(:product_action, :store, 
       credit(account: :clicks_service, accountable: @organization, amount: amount)
       debit(account: :available_store_funds, accountable: @store, amount: amount)
     end
+    @store.update_has_enough_balance
   end
 end

--- a/app/commands/promoted_click_accounter.rb
+++ b/app/commands/promoted_click_accounter.rb
@@ -2,7 +2,7 @@ class PromotedClickAccounter < PowerTypes::Command.new(:product_action, :organiz
   include Ledgerizer::Execution::Dsl
 
   def perform
-    amount = Money.from_amount(ENV.fetch('CPC').to_i)
+    amount = Money.from_amount(ProductAction::PROMOTED_CLICK_COST)
     store = @product_action.store
     execute_promoted_click_entry(
       tenant: @organization,

--- a/app/commands/promoted_click_accounter.rb
+++ b/app/commands/promoted_click_accounter.rb
@@ -1,16 +1,17 @@
-class PromotedClickAccounter < PowerTypes::Command.new(:product_action, :store, :organization)
+class PromotedClickAccounter < PowerTypes::Command.new(:product_action, :organization)
   include Ledgerizer::Execution::Dsl
 
   def perform
     amount = Money.from_amount(ENV.fetch('CPC').to_i)
+    store = @product_action.store
     execute_promoted_click_entry(
       tenant: @organization,
       document: @product_action,
       date: @product_action.created_at
     ) do
       credit(account: :clicks_service, accountable: @organization, amount: amount)
-      debit(account: :available_store_funds, accountable: @store, amount: amount)
+      debit(account: :available_store_funds, accountable: store, amount: amount)
     end
-    @store.update_has_enough_balance
+    store.update_has_enough_balance
   end
 end

--- a/app/jobs/promoted_click_accounter_job.rb
+++ b/app/jobs/promoted_click_accounter_job.rb
@@ -4,7 +4,6 @@ class PromotedClickAccounterJob < ApplicationJob
   def perform(product_action, organization)
     PromotedClickAccounter.for(
       organization: organization,
-      store: product_action.store,
       product_action: product_action
     )
   end

--- a/app/models/product_action.rb
+++ b/app/models/product_action.rb
@@ -9,6 +9,8 @@ class ProductAction < ApplicationRecord
   validates :action_type, presence: true
 
   delegate :store, to: :product
+
+  PROMOTED_CLICK_COST = ENV.fetch('CPC').to_i
 end
 
 # == Schema Information

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -13,6 +13,11 @@ class Store < ApplicationRecord
   def final_balance
     accounts.first.ledger_balance.format
   end
+
+  def update_has_enough_balance
+    cpc = ENV.fetch('CPC').to_i
+    update(has_enough_balance: accounts.first.ledger_balance.fractional >= cpc)
+  end
 end
 
 # == Schema Information

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -30,6 +30,7 @@ end
 #  region_id              :bigint(8)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  has_enough_balance     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -15,7 +15,7 @@ class Store < ApplicationRecord
   end
 
   def update_has_enough_balance
-    cpc = ENV.fetch('CPC').to_i
+    cpc = ProductAction::PROMOTED_CLICK_COST
     update(has_enough_balance: accounts.first.ledger_balance.fractional >= cpc)
   end
 end

--- a/db/migrate/20191017140758_add_has_enough_balance_to_stores.rb
+++ b/db/migrate/20191017140758_add_has_enough_balance_to_stores.rb
@@ -1,0 +1,5 @@
+class AddHasEnoughBalanceToStores < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stores, :has_enough_balance, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_15_190844) do
+ActiveRecord::Schema.define(version: 2019_10_17_140758) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -189,6 +189,7 @@ ActiveRecord::Schema.define(version: 2019_10_15_190844) do
     t.bigint "region_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "has_enough_balance", default: false
     t.index ["email"], name: "index_stores_on_email", unique: true
     t.index ["region_id"], name: "index_stores_on_region_id"
     t.index ["reset_password_token"], name: "index_stores_on_reset_password_token", unique: true

--- a/spec/commands/deposit_accounter_spec.rb
+++ b/spec/commands/deposit_accounter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe DepositAccounter do
-  let(:deposit) { build(:deposit, :without_execute_store_deposit, created_at: Date.current) }
+  let(:deposit) { build(:deposit) }
 
   def perform
     described_class.new(deposit: deposit).perform
@@ -43,4 +43,15 @@ describe DepositAccounter do
     )
   end
   # rubocop:enable RSpec/ExampleLength
+
+  context "with store with has_enough_balance false" do
+    let(:store) { build(:store, has_enough_balance: false) }
+    let(:deposit) { build(:deposit, store: store) }
+
+    it "updates store has_enough_balance to true" do
+      perform
+
+      expect(deposit.store.has_enough_balance).to be(true)
+    end
+  end
 end

--- a/spec/commands/promoted_click_accounter_spec.rb
+++ b/spec/commands/promoted_click_accounter_spec.rb
@@ -6,7 +6,12 @@ describe PromotedClickAccounter do
   let(:amount) { ProductAction::PROMOTED_CLICK_COST }
   let(:product_action) do
     product = build(:product, store: store)
-    build(:product_action, product: product, created_at: Date.current)
+    build(
+      :product_action,
+      action_type: 'promoted_click',
+      product: product,
+      created_at: Date.current
+    )
   end
 
   def perform
@@ -48,5 +53,21 @@ describe PromotedClickAccounter do
       accountable: store,
       amount: Money.from_amount(amount * -1)
     )
+  end
+
+  context "with store with balance enough for one click" do
+    let(:product_action) do
+      build(
+        :product_action,
+        created_at: Date.current,
+        action_type: 'promoted_click'
+      )
+    end
+
+    it "updates store has_enough_balance to false" do
+      perform
+
+      expect(product_action.store.has_enough_balance).to be(false)
+    end
   end
 end

--- a/spec/commands/promoted_click_accounter_spec.rb
+++ b/spec/commands/promoted_click_accounter_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe PromotedClickAccounter do
   let(:store) { build(:store) }
   let(:organization) { build(:organization) }
-  let(:amount) { ENV.fetch('CPC').to_i }
+  let(:amount) { ProductAction::PROMOTED_CLICK_COST }
   let(:product_action) do
     product = build(:product, store: store)
     build(:product_action, product: product, created_at: Date.current)

--- a/spec/commands/promoted_click_accounter_spec.rb
+++ b/spec/commands/promoted_click_accounter_spec.rb
@@ -11,7 +11,6 @@ describe PromotedClickAccounter do
 
   def perform
     described_class.new(
-      store: store,
       organization: organization,
       product_action: product_action
     ).perform

--- a/spec/factories/deposits.rb
+++ b/spec/factories/deposits.rb
@@ -6,8 +6,4 @@ FactoryBot.define do
     amount_currency { 'CLP' }
     deposit_time { Date.current }
   end
-
-  trait :without_execute_store_deposit do
-    after(:build) { |d| d.class.skip_callback(:save, :after, :execute_store_deposit, raise: false) }
-  end
 end

--- a/spec/factories/stores.rb
+++ b/spec/factories/stores.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     password { '123456' }
     region
     name { 'SuperStore' }
+    has_enough_balance { false }
   end
 end

--- a/spec/jobs/promoted_click_accounter_job_spec.rb
+++ b/spec/jobs/promoted_click_accounter_job_spec.rb
@@ -11,8 +11,7 @@ describe PromotedClickAccounterJob do
     expect(PromotedClickAccounter).to(
       have_received(:for).with(
         product_action: product_action,
-        organization: organization,
-        store: product_action.store
+        organization: organization
       )
     )
   end


### PR DESCRIPTION
* Se agrega el campo has_enough_balance al modelo store, que simboliza si la tienda tiene saldo suficiente para recibir un cobro de click promocionado. El campo es para ser revisado por el recomendador (en la bd).
* Este campo se actualiza al finalizar los comandos de Deposit y de PromotedClick.
* Se aprovecha de rehacer el command del promoted click para usar el delegate de store el product_action.
* Se crea un método estático en la clase ProductAction, para obtener el valor del costo de un promoted_click, que es una variables de entorno (se hizo así para poder cambiarlo mas rápido al principio, cuando se defina bien el costo se va a cambiar).
* Se agregan test para las nuevas responsabilidades de los commands (actualizar el campo nuevo).