### PR TITLE
Fix/improve cookies secutiry

### DIFF
--- a/app/controllers/api/v1/product_actions_controller.rb
+++ b/app/controllers/api/v1/product_actions_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::ProductActionsController < Api::V1::BaseController
 
   def save_action(action_type)
     ProductAction.create!(
-      receiver_id: receiver_id,
+      receiver_id: receiver.id,
       product_id: permitted_params[:product_id],
       action_type: action_type
     )
@@ -24,9 +24,5 @@ class Api::V1::ProductActionsController < Api::V1::BaseController
     if product&.promoted && product&.store&.has_enough_balance?
       save_action('promoted_click')
     end
-  end
-
-  def receiver_id
-    session[:receiver_id]
   end
 end

--- a/app/controllers/api/v1/product_actions_controller.rb
+++ b/app/controllers/api/v1/product_actions_controller.rb
@@ -27,6 +27,6 @@ class Api::V1::ProductActionsController < Api::V1::BaseController
   end
 
   def receiver_id
-    cookies[:receiver_id]
+    session[:receiver_id]
   end
 end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -20,14 +20,14 @@ class Api::V1::ProductsController < Api::V1::BaseController
   end
 
   def receiver
-    receiver_id = cookies[:receiver_id]
+    receiver_id = session[:receiver_id]
     return if receiver_id.blank?
 
     Receiver.find_by(id: receiver_id)
   end
 
   def giver_id
-    giver_id = cookies[:giver_id]
+    giver_id = session[:giver_id]
     return if giver_id.blank?
 
     giver_id.to_i

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -19,25 +19,11 @@ class Api::V1::ProductsController < Api::V1::BaseController
     params.permit(:number_of_products, :min_price, :max_price, :promoted)
   end
 
-  def receiver
-    receiver_id = session[:receiver_id]
-    return if receiver_id.blank?
-
-    Receiver.find_by(id: receiver_id)
-  end
-
-  def giver_id
-    giver_id = session[:giver_id]
-    return if giver_id.blank?
-
-    giver_id.to_i
-  end
-
   def redirect_to_landing_if_receiver_not_valid
     redirect_to landing_show_path unless receiver_is_valid?
   end
 
   def receiver_is_valid?
-    receiver && giver_id && (receiver.giver_id == giver_id)
+    receiver && giver && (receiver.giver_id == giver.id)
   end
 end

--- a/app/controllers/api/v1/receivers_controller.rb
+++ b/app/controllers/api/v1/receivers_controller.rb
@@ -9,10 +9,4 @@ class Api::V1::ReceiversController < Api::V1::BaseController
       format.json { head :ok }
     end
   end
-
-  private
-
-  def receiver
-    @receiver ||= Receiver.find_by(id: session[:receiver_id])
-  end
 end

--- a/app/controllers/api/v1/receivers_controller.rb
+++ b/app/controllers/api/v1/receivers_controller.rb
@@ -3,13 +3,16 @@ class Api::V1::ReceiversController < Api::V1::BaseController
     respond_with receiver if receiver
   end
 
+  def delete_session
+    session.delete(:receiver_id)
+    respond_to do |format|
+      format.json { head :ok }
+    end
+  end
+
   private
 
   def receiver
-    @receiver ||= Receiver.find_by(id: permitted_params)
-  end
-
-  def permitted_params
-    params.require(:id)
+    @receiver ||= Receiver.find_by(id: session[:receiver_id])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  private
+
+  def giver
+    @giver ||= Giver.find_by(id: session[:giver_id])
+  end
+
+  def receiver
+    @receiver ||= Receiver.find_by(id: session[:receiver_id])
+  end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,4 @@
 class HomeController < ApplicationController
-  before_action :set_receiver, :set_giver, only: :show
   before_action :check_redirect_to_landing, only: :show
 
   def show; end
@@ -7,16 +6,8 @@ class HomeController < ApplicationController
   private
 
   def check_redirect_to_landing
-    if !@giver || !@receiver || @receiver.giver_id != @giver.id
+    if !giver || !receiver || receiver.giver_id != giver.id
       redirect_to landing_show_path
     end
-  end
-
-  def set_receiver
-    @receiver = Receiver.find_by(id: session[:receiver_id])
-  end
-
-  def set_giver
-    @giver = Giver.find_by(id: session[:giver_id])
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,5 @@
 class HomeController < ApplicationController
-  before_action :set_receiver_id, :set_giver_id, only: :show
+  before_action :set_receiver, :set_giver, only: :show
   before_action :redirect_to_landing_if_no_cookies, only: :show
 
   def show; end
@@ -7,14 +7,16 @@ class HomeController < ApplicationController
   private
 
   def redirect_to_landing_if_no_cookies
-    redirect_to landing_show_path if !@giver_id
+    if !@giver || !@receiver || @receiver.giver_id != @giver.id
+      redirect_to landing_show_path
+    end
   end
 
-  def set_receiver_id
-    @receiver_id = cookies[:receiver_id]
+  def set_receiver
+    @receiver = Receiver.find_by(id: cookies[:receiver_id])
   end
 
-  def set_giver_id
-    @giver_id = cookies[:giver_id]
+  def set_giver
+    @giver = Giver.find_by(id: cookies[:giver_id])
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,22 +1,22 @@
 class HomeController < ApplicationController
   before_action :set_receiver, :set_giver, only: :show
-  before_action :redirect_to_landing_if_no_cookies, only: :show
+  before_action :check_redirect_to_landing, only: :show
 
   def show; end
 
   private
 
-  def redirect_to_landing_if_no_cookies
+  def check_redirect_to_landing
     if !@giver || !@receiver || @receiver.giver_id != @giver.id
       redirect_to landing_show_path
     end
   end
 
   def set_receiver
-    @receiver = Receiver.find_by(id: cookies[:receiver_id])
+    @receiver = Receiver.find_by(id: session[:receiver_id])
   end
 
   def set_giver
-    @giver = Giver.find_by(id: cookies[:giver_id])
+    @giver = Giver.find_by(id: session[:giver_id])
   end
 end

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -7,17 +7,17 @@ class LandingController < ApplicationController
 
   def search
     create_giver_and_receiver
-    save_giver_cookies(@giver.id)
-    save_receiver_cookies(@receiver.id)
+    save_giver_session(@giver.id)
+    save_receiver_session(@receiver.id)
     redirect_to home_path
   end
 
-  def save_giver_cookies(giver_id)
-    cookies[:giver_id] = giver_id
+  def save_giver_session(giver_id)
+    session[:giver_id] = giver_id
   end
 
-  def save_receiver_cookies(receiver_id)
-    cookies[:receiver_id] = receiver_id
+  def save_receiver_session(receiver_id)
+    session[:receiver_id] = receiver_id
   end
 
   private
@@ -27,7 +27,7 @@ class LandingController < ApplicationController
   end
 
   def set_giver
-    @giver = Giver.find_by(id: cookies[:giver_id])
+    @giver = Giver.find_by(id: session[:giver_id])
   end
 
   def create_giver_and_receiver

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -1,23 +1,22 @@
 class LandingController < ApplicationController
   before_action :check_for_receiver, only: :show
-  before_action :set_giver, only: :search
 
   DEFAULT_REGION = ENV.fetch('DEFAULT_REGION', 1).to_i
   def show; end
 
   def search
     create_giver_and_receiver
-    save_giver_session(@giver.id)
-    save_receiver_session(@receiver.id)
+    save_giver_session
+    save_receiver_session
     redirect_to home_path
   end
 
-  def save_giver_session(giver_id)
-    session[:giver_id] = giver_id
+  def save_giver_session
+    session[:giver_id] = giver.id
   end
 
-  def save_receiver_session(receiver_id)
-    session[:receiver_id] = receiver_id
+  def save_receiver_session
+    session[:receiver_id] = receiver.id
   end
 
   private
@@ -26,15 +25,11 @@ class LandingController < ApplicationController
     search if params[:name]
   end
 
-  def set_giver
-    @giver = Giver.find_by(id: session[:giver_id])
-  end
-
   def create_giver_and_receiver
-    @giver = Giver.create!(region_id: DEFAULT_REGION) if @giver.blank?
+    @giver = Giver.create!(region_id: DEFAULT_REGION) if giver.blank?
     @receiver = Receiver.create!(
       name: params[:name],
-      giver_id: @giver.id
+      giver_id: giver.id
     )
   end
 end

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -1,5 +1,6 @@
 class LandingController < ApplicationController
   before_action :check_for_receiver, only: :show
+  before_action :set_giver, only: :search
 
   DEFAULT_REGION = ENV.fetch('DEFAULT_REGION', 1).to_i
   def show; end
@@ -25,8 +26,12 @@ class LandingController < ApplicationController
     search if params[:name]
   end
 
+  def set_giver
+    @giver = Giver.find_by(id: cookies[:giver_id])
+  end
+
   def create_giver_and_receiver
-    @giver = Giver.create!(region_id: DEFAULT_REGION)
+    @giver = Giver.create!(region_id: DEFAULT_REGION) if @giver.blank?
     @receiver = Receiver.create!(
       name: params[:name],
       giver_id: @giver.id

--- a/app/javascript/packs/home.js
+++ b/app/javascript/packs/home.js
@@ -1,10 +1,7 @@
 import Vue from 'vue';
-import VueCookies from 'vue-cookies';
 import router from '../src/router';
 import store from '../src/store/index';
 import app from '../src/app';
-
-Vue.use(VueCookies);
 
 document.addEventListener('DOMContentLoaded', () => {
   if (document.getElementById('home') !== null) {

--- a/app/javascript/src/api/receiver.js
+++ b/app/javascript/src/api/receiver.js
@@ -1,11 +1,19 @@
 import api from './index';
 
 export default {
-  getReceiver(receiverId) {
-    const path = `/api/v1/receivers/${receiverId}`;
+  getReceiver() {
+    const path = '/api/v1/receivers/get';
 
     return api({
       method: 'get',
+      url: path,
+    });
+  },
+  deleteSession() {
+    const path = '/api/v1/receivers/delete_session';
+
+    return api({
+      method: 'delete',
       url: path,
     });
   },

--- a/app/javascript/src/store/index.js
+++ b/app/javascript/src/store/index.js
@@ -41,8 +41,8 @@ const store = new Vuex.Store({
     },
   },
   actions: {
-    getReceiverName: (context, payload) => {
-      receiverApi.getReceiver(payload).then((response) => {
+    getReceiverName: (context) => {
+      receiverApi.getReceiver().then((response) => {
         const receiverName = response.name;
         context.commit('setReceiverName', receiverName);
       });
@@ -71,6 +71,11 @@ const store = new Vuex.Store({
     },
     markClicked: (context, payload) => {
       productsApi.markClicked(payload);
+    },
+    deleteSessionReceiver: () => {
+      receiverApi.deleteSession()
+        .then(() => window.location.reload())
+        .catch(() => {});
     },
     moreProducts: context => new Promise((resolve, reject) => {
       const params = [

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -114,14 +114,11 @@ export default {
       this.visiblePriceFilter = !this.visiblePriceFilter;
     },
     clearCookies() {
-      this.$cookies.keys().forEach(
-        cookie => this.$cookies.remove(cookie)
-      );
-      window.location.reload();
+      this.$store.dispatch('deleteSessionReceiver');
     },
   },
   created() {
-    this.$store.dispatch('getReceiverName', this.$cookies.get('receiver_id'));
+    this.$store.dispatch('getReceiverName');
   },
   mounted() {
     this.$store.dispatch('getProducts');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,8 @@ Rails.application.routes.draw do
     api_version(module: "Api::V1", path: { value: "v1" }, defaults: { format: 'json' }) do
       resources :products, only: [:index]
       resources :product_actions, only: [:create]
-      resources :receivers, only: [:show]
+      get 'receivers/get', to: 'receivers#show'
+      delete 'receivers/delete_session', to: 'receivers#delete_session'
       resources :catalogs, only: [:update]
     end
   end

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "axios": "^0.19.0",
     "humps": "^2.0.1",
     "vue": "^2.6.10",
-    "vue-cookies": "^1.5.13",
     "vue-loader": "^15.7.1",
     "vue-router": "^3.1.2",
     "vue-spinner": "^1.0.3",

--- a/spec/controllers/api/v1/product_actions_controller_spec.rb
+++ b/spec/controllers/api/v1/product_actions_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Api::V1::ProductActionsController, type: :controller do
     end
 
     before do
-      request.cookies['receiver_id'] = receiver.id
+      session['receiver_id'] = receiver.id
     end
 
     it 'returns http success' do

--- a/spec/controllers/api/v1/products_controller_spec.rb
+++ b/spec/controllers/api/v1/products_controller_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Api::V1::ProductsController, type: :controller do
 
     context 'with proper session' do
       before do
-        request.cookies['receiver_id'] = receiver.id
-        request.cookies['giver_id'] = giver.id
+        session['receiver_id'] = receiver.id
+        session['giver_id'] = giver.id
         get :index, params: { number_of_products: "5", format: :json }
       end
 
@@ -19,7 +19,7 @@ RSpec.describe Api::V1::ProductsController, type: :controller do
 
     context 'without giver_id' do
       before do
-        request.cookies['receiver_id'] = receiver.id
+        session['receiver_id'] = receiver.id
         get :index, params: { number_of_products: "5", format: :json }
       end
 
@@ -30,7 +30,7 @@ RSpec.describe Api::V1::ProductsController, type: :controller do
 
     context 'without receiver_id' do
       before do
-        request.cookies['giver_id'] = giver.id
+        session['giver_id'] = giver.id
         get :index, params: { number_of_products: "5", format: :json }
       end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7527,11 +7527,6 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
   integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
 
-vue-cookies@^1.5.13:
-  version "1.5.13"
-  resolved "https://registry.yarnpkg.com/vue-cookies/-/vue-cookies-1.5.13.tgz#b1ca79a2663bf9a4f36982557011cab5ee2196c0"
-  integrity sha512-8pjpXnvbNWx1Lft0t3MJnW+ylv0Wa2Tb6Ch617u/pQah3+SfXUZZdkh3EL3bSpe/Sw2Wdw3+DhycgQsKANSxXg==
-
 vue-eslint-parser@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-5.0.0.tgz#00f4e4da94ec974b821a26ff0ed0f7a78402b8a1"


### PR DESCRIPTION
* Se cambia el uso de cookies por session de rails (la cookie se maneja automáticamente).
* Si el receiver no es del giver, se redirecciona a la pagina inicial.
* Se crea una nueva ruta para poder eliminar la session[:receiver_id], y se implementa en el frontend.
* Se quita el package vue-cookies, ya que no se usa ahora.
* Se arreglan los tests, para utilizar session en vez de cookies.