### PR TITLE
Feat/filter alway visible desktop

### DIFF
--- a/app/javascript/src/components/home-header.vue
+++ b/app/javascript/src/components/home-header.vue
@@ -22,7 +22,7 @@
           @click="goToStore"
         >
         <price-filter
-          v-if="visiblePriceFilter"
+          v-if="visiblePriceFilter || desktop"
           :mobile="mobile"
           @filtered="togglePriceFilter"
         />
@@ -30,13 +30,13 @@
           class="home-header__icon"
           src="../assets/currency.svg"
           @click="togglePriceFilter"
-          v-if="!visiblePriceFilter"
+          v-if="!visiblePriceFilter && !desktop"
         >
         <img
           class="home-header__icon home-header__icon--small"
           src="../assets/close-badge-blue.svg"
           @click="togglePriceFilter"
-          v-if="visiblePriceFilter"
+          v-if="visiblePriceFilter && !desktop"
         >
       </div>
     </div>
@@ -47,14 +47,17 @@ import HeaderCenter from './header-center';
 import PriceFilter from './price-filter';
 
 const MOBILE_WIDTH = 650;
+const TABLET_WIDTH = 1000;
 const SCROLL_OFFSET = 60;
 
 export default {
   name: 'HomeHeader',
   data() {
+    const desktop = window.innerWidth > TABLET_WIDTH;
     return {
       mobile: window.innerWidth <= MOBILE_WIDTH,
-      visiblePriceFilter: false,
+      desktop,
+      visiblePriceFilter: desktop,
     };
   },
   props: {
@@ -76,6 +79,7 @@ export default {
     },
     onResize() {
       this.mobile = window.innerWidth <= MOBILE_WIDTH;
+      this.desktop = window.innerWidth > TABLET_WIDTH;
     },
   },
   mounted() {

--- a/app/javascript/src/components/home-header.vue
+++ b/app/javascript/src/components/home-header.vue
@@ -26,12 +26,13 @@
           :mobile="mobile"
           @filtered="togglePriceFilter"
         />
-        <img
+        <div
           class="home-header__icon"
-          src="../assets/currency.svg"
           @click="togglePriceFilter"
           v-if="!visiblePriceFilter && !desktop"
         >
+          Filtrar
+        </div>
         <img
           class="home-header__icon home-header__icon--small"
           src="../assets/close-badge-blue.svg"
@@ -127,8 +128,8 @@ export default {
       position: absolute;
       right: 0;
       top: .7em;
-      width: 1.3em;
       height: 1.3em;
+      color: $c-header-foreground;
 
       &--small {
         width: .8em;

--- a/app/javascript/src/components/price-filter.vue
+++ b/app/javascript/src/components/price-filter.vue
@@ -77,7 +77,7 @@ export default {
     z-index: 105;
     width: 100%;
     top: 3em;
-    padding: 2em;
+    padding: 1.8em;
 
     &__form {
       display: flex;


### PR DESCRIPTION
* El filtro de precios se deja visible siempre en desktop.
* Se cambia el ícono para mostrar el filtro, por la palabra "Filtrar"
* Se aprovecha de ajustar el padding del filtro de precios, para que no se salga del header.