### PR TITLE
fix(aa): resize product image in show and edit

### DIFF
--- a/app/admin/store_products.rb
+++ b/app/admin/store_products.rb
@@ -73,13 +73,7 @@ ActiveAdmin.register Product do
       f.input :name
       f.input :price
       f.input :link
-      image = f.object.image
-      hint = if image_attached?
-               image_tag(url_for(image), size: 250, class: "aa-product__image")
-             else
-               content_tag(:span, 'Sin imagen')
-             end
-      f.input :image, as: :file, hint: hint
+      f.input :image, as: :file, hint: image_hint(f.object.image)
       f.input :promoted
       f.input :display
       f.input :gender

--- a/app/admin/store_products.rb
+++ b/app/admin/store_products.rb
@@ -49,7 +49,7 @@ ActiveAdmin.register Product do
       row :clicks
       row :link
       row :image do |product|
-        image_tag(url_for(product.image)) if product.image.attached?
+        image_tag(url_for(product.image), size: 250) if product.image.attached?
       end
       row :clicks_cost
       row :store
@@ -72,7 +72,7 @@ ActiveAdmin.register Product do
       f.input :price
       f.input :link
       image = f.object.image
-      hint = image.attached? ? image_tag(url_for(image)) : content_tag(:span, "Sin imagen")
+      hint = image.attached? ? image_tag(url_for(image), size: 250) : content_tag(:span, "Sin imagen")
       f.input :image, as: :file, hint: hint
       f.input :promoted
       f.input :display

--- a/app/admin/store_products.rb
+++ b/app/admin/store_products.rb
@@ -49,7 +49,9 @@ ActiveAdmin.register Product do
       row :clicks
       row :link
       row :image do |product|
-        image_tag(url_for(product.image), size: 250) if product.image.attached?
+        if product.image.attached?
+          image_tag(url_for(product.image), size: 250, class: "aa-product__image")
+        end
       end
       row :clicks_cost
       row :store
@@ -72,7 +74,11 @@ ActiveAdmin.register Product do
       f.input :price
       f.input :link
       image = f.object.image
-      hint = image.attached? ? image_tag(url_for(image), size: 250) : content_tag(:span, "Sin imagen")
+      hint = if image_attached?
+               image_tag(url_for(image), size: 250, class: "aa-product__image")
+             else
+               content_tag(:span, 'Sin imagen')
+             end
       f.input :image, as: :file, hint: hint
       f.input :promoted
       f.input :display

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -23,3 +23,6 @@ $panelHeaderBck: #002744;
 // For example, to change the default status-tag color:
 //
 //   .status_tag { background: #6090DB; }
+.aa-product__image {
+  object-fit: cover;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,4 +9,10 @@ module ApplicationHelper
   def default_display
     DEFAULT_DISPLAY
   end
+
+  def image_hint(image)
+    return image_tag(url_for(image), size: 250, class: 'aa-product__image') if image.attached?
+
+    content_tag(:span, 'Sin imagen')
+  end
 end


### PR DESCRIPTION
Se escala la imagen a 250x250 para evitar que imágenes muy grandes sean difíciles de ver al editar los productos.