### PR TITLE
fix(frontend/api-products): use + to cut string in two lines

### DIFF
--- a/app/javascript/src/api/products.js
+++ b/app/javascript/src/api/products.js
@@ -3,8 +3,8 @@ import api from './index';
 
 export default {
   products(numberOfProducts, minPrice, maxPrice, numberOfPromoted) {
-    const path = `/api/v1/products?number_of_products=${numberOfProducts}&min_price=${minPrice}\\
-      &max_price=${maxPrice}&promoted=${numberOfPromoted}`;
+    const path = `/api/v1/products?number_of_products=${numberOfProducts}&min_price=${minPrice}` +
+      `&max_price=${maxPrice}&promoted=${numberOfPromoted}`;
 
     return api({
       method: 'get',


### PR DESCRIPTION
* Se cambia el método para romper el string en dos lineas. Ahora se usa `+` en vez de `\`.