### PR TITLE
Product status on Active Admin

### DIFF
--- a/app/admin/store_products.rb
+++ b/app/admin/store_products.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register Product do
   menu parent: I18n.t('activeadmin.titles.stores')
 
-  permit_params :store_id, :name, :price, :link, :promoted, :display, :gender, :age, :novelty
+  permit_params :store_id, :name, :price, :link, :gender, :age, :novelty, :status
 
   filter :name
   filter :store
@@ -15,12 +15,11 @@ ActiveAdmin.register Product do
     column :name
     column :price
     column :link
-    column :promoted
-    column :display
     column :gender
     column :age
     column :novelty
     column :created_at
+    column :status
     actions
   end
 
@@ -57,13 +56,12 @@ ActiveAdmin.register Product do
       row :store
       row :created_at
       row :updated_at
-      row :display
-      row :promoted
       row :deleted
       row :average_color
       row :gender
       row :age
       row :novelty
+      row :status
     end
   end
 
@@ -74,8 +72,6 @@ ActiveAdmin.register Product do
       f.input :price
       f.input :link
       f.input :image, as: :file, hint: image_hint(f.object.image)
-      f.input :promoted
-      f.input :display
       f.input :gender
       f.input :age
       f.input :novelty

--- a/app/admin/store_products.rb
+++ b/app/admin/store_products.rb
@@ -8,6 +8,7 @@ ActiveAdmin.register Product do
   filter :price
   filter :link
   filter :created_at
+  filter :status, as: :select
 
   index do
     id_column
@@ -32,12 +33,18 @@ ActiveAdmin.register Product do
     def update
       super
       update_image
+      update_status
     end
 
     private
 
     def update_image
       @product.update_image(params[:product][:image]) if params[:product][:image].present?
+    end
+
+    def update_status
+      @product.approve! if :status == 'approved'
+      @product.reject! if :status == 'rejected'
     end
   end
 
@@ -75,6 +82,9 @@ ActiveAdmin.register Product do
       f.input :gender
       f.input :age
       f.input :novelty
+      f.input :status, as: :select, collection: { 'Awaiting Approval' => 'awaiting_approval',
+                                                  'Approved' => 'approved',
+                                                  'Rejected' => 'rejected' }
     end
     f.actions
   end

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -19,6 +19,7 @@ es-CL:
         deposit_time: Fecha depósito
       product:
         status:
+          one: Estado
           awaiting_approval: Esperando aprobación
           approved: Aprobado
           rejected: Rechazado


### PR DESCRIPTION
### Contexto
Se quiere que los productos que aparezcan en la plataforma deban ser aprobados por el admin.

### Qué se esta haciendo
Este PR agrega el status del producto en el dashboard del admin, en el filter, y en el view y edit del producto. Además quita las columnas de `display ` y `promoted` que ya no serán usadas.