### PR TITLE
feat(api): products are returned on a random order

### DIFF
--- a/app/commands/get_products_recommendation.rb
+++ b/app/commands/get_products_recommendation.rb
@@ -1,12 +1,12 @@
 class GetProductsRecommendation < PowerTypes::Command.new(
-  :receiver, :number_of_products, :promoted, min_price: false, max_price: false
+  :receiver, :number_of_products, :promoted, min_price: false, max_price: false, page: 0, seed: 0
 )
   URL = ENV.fetch('RECOMMENDER_URL')
   def perform
     if product_ids = perform_recommendation_request
       Product.find_with_order(product_ids)
     else
-      Product.first(@number_of_products.to_i)
+      Product.randomized(@seed).page(@page).per(@number_of_products)
     end
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -31,6 +31,11 @@ class Product < ApplicationRecord
     set_average_color
   end
 
+  def self.randomized(seed = 0.0)
+    connection.execute(Arel.sql("SELECT SETSEED(#{seed})"))
+    order(Arel.sql('RANDOM()'))
+  end
+
   def update_image(image_param)
     image.attach(image_param)
     update_recommender_image

--- a/spec/commands/get_products_recommendation_spec.rb
+++ b/spec/commands/get_products_recommendation_spec.rb
@@ -44,7 +44,7 @@ describe GetProductsRecommendation do
     end
 
     it 'returns some products' do
-      expect(perform).to eq(Product.first(3))
+      expect(perform).to eq(Product.randomized(0).page(0).per(3))
     end
   end
 end

--- a/spec/controllers/api/v1/products_controller_spec.rb
+++ b/spec/controllers/api/v1/products_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Api::V1::ProductsController, type: :controller do
       before do
         session['receiver_id'] = receiver.id
         session['giver_id'] = giver.id
+        session['seed'] = 0.0
         get :index, params: { number_of_products: "5", format: :json }
       end
 


### PR DESCRIPTION
### Contexto

Queremos mostrar en la página "regalos universales" en vez de un catálogo. Como ya no se va a usar el recomendador, queremos que se muestren los productos en orden aleatorio, y sólo se repitan los regalos cuando ya se han visto todos.

### Qué se está haciendo

En el PR se modifica la lógica del controlador de productos. Cuando se hace un request por primera vez, se fija una seed, y se van devolviendo los productos ordenados al azar, pero con esa seed, y de forma paginada.
Cuando se acaban las páginas, se cambia la seed.
La seed y el paginamiento hacen que los productos aparezcan en un orden al azar, y como se mantiene la seed hasta que se acaban las páginas, se logra que no se repitan hasta que se hayan visto todos al menos una vez.

No se modificó el código del front-end, así que en la página los productos siguen ordenados por id. Esto se puede cambiar fácilmente, pero pensé dejarlo para cuando se cambie el layout de la página principal.