### PR TITLE
Disable notifications on development

### DIFF
--- a/app/observers/product_observer.rb
+++ b/app/observers/product_observer.rb
@@ -1,5 +1,5 @@
 class ProductObserver < PowerTypes::Observer
-  after_create :notify_slack
+  after_create :notify_slack unless Rails.env.development?
 
   def notify_slack
     NotifySlackJob.perform_later(object)


### PR DESCRIPTION
Este PR desactiva las notificaciones al añadir la condición al observer para que ejecute `NotifySlackJob` sólo cuando `Rails.env` no es `development`.