### PR TITLE
Fix production creation timeout bug

### DIFF
--- a/app/controllers/stores/catalog_controller.rb
+++ b/app/controllers/stores/catalog_controller.rb
@@ -44,7 +44,6 @@ class Stores::CatalogController < ApplicationController
     if params[:image]
       @product = Product.create!(product_params)
       @product.update_image(params[:image])
-      @product.update(display: true)
     end
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -32,7 +32,7 @@ class Product < ApplicationRecord
   end
 
   def set_average_color
-    image = MiniMagick::Image.open(url_for(self.image))
+    image = MiniMagick::Image.open(ActiveStorage::Blob.service.path_for(self.image.key))
     red, blue, green = image.resize("1x1").get_pixels[0][0]
     update(average_color: hex_value(red, blue, green))
   end


### PR DESCRIPTION
Este PR soluciona el error de timeout al crear un nuevo producto. 

El timeout se debía a los métodos `set_average_color` y `update_recommender_image` que eran llamados desde `update_image`. Cuando se hacía `open` a las imágenes, el request bloqueaba el response por abrir una url del mismo servidor, por lo que se reemplazó por un path local. 
Al solucionar eso, @sleivav me informó que quedaba una línea haciendo referencia a `display` que causaba error al crear el producto, que también fue eliminada.

**Sólo se corrigió en `set_average_color`** porque el método del recomendador debe desaparecer en el PR #153.