### PR TITLE
Feat/favorite categories

### DIFF
--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -7,6 +7,7 @@
     >
       <div class="product-card">
         <div
+          v-if="!hideFavoriteButton"
           class="product-card__icon-container"
           @click="setLikeStatus"
         >
@@ -101,6 +102,10 @@ export default {
     category: {
       type: Object,
       default: null,
+    },
+    hideFavoriteButton: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {

--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -6,6 +6,21 @@
       class="category__main-product"
     >
       <div class="product-card">
+        <div
+          class="product-card__icon-container"
+          @click="setLikeStatus"
+        >
+          <img
+            v-if="isLiked"
+            class="product-card__icon product-card__icon--active"
+            src="../assets/like-color-badge.svg"
+          >
+          <img
+            v-else
+            class="product-card__icon"
+            src="../assets/like-badge.svg"
+          >
+        </div>
         <product-image
           :product="selectedProduct"
           @click.native="clickAction"
@@ -48,7 +63,7 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
+import { mapActions, mapState } from 'vuex';
 import convertToClp from '../utils/convert-to-clp';
 
 import productImage from './product-image';
@@ -74,6 +89,13 @@ export default {
     changeProduct(index) {
       this.selectedProductIndex = index;
     },
+    setLikeStatus() {
+      if (this.isLiked) {
+        this.$store.commit('removeFavoriteCategory', this.category.id);
+      } else {
+        this.$store.commit('addFavoriteCategory', this.category);
+      }
+    },
   },
   props: {
     category: {
@@ -82,6 +104,12 @@ export default {
     },
   },
   computed: {
+    ...mapState([
+      'favoriteCategories',
+    ]),
+    isLiked() {
+      return this.category.id in this.favoriteCategories;
+    },
     selectedProduct() {
       return this.category.products[this.selectedProductIndex];
     },
@@ -101,6 +129,28 @@ export default {
 
 <style lang="scss">
   @import '../../styles/variables';
+
+  @keyframes pump {
+    50% {
+      transform: scale(1);
+    }
+
+    55% {
+      transform: scale(1.2);
+    }
+
+    60% {
+      transform: scale(1);
+    }
+
+    65% {
+      transform: scale(1.2);
+    }
+
+    70% {
+      transform: scale(1);
+    }
+  }
 
   .category {
     display: flex;
@@ -152,6 +202,37 @@ export default {
     box-shadow: 0 2px 6px rgba(148, 148, 148, .24);
     border-radius: 6px;
     background-color: #fff;
+
+    &__icon {
+      width: 80%;
+      height: 80%;
+      margin: .17em;
+      cursor: pointer;
+
+      &--active {
+        animation: pump 6s;
+        animation-iteration-count: infinite;
+      }
+    }
+
+    &__icon-container {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      height: 1.5em;
+      width: 1.5em;
+      border-radius: 50%;
+      padding: .1em;
+      background-color: #fff;
+      box-shadow: 0 4px 6px 0 rgba(43, 43, 43, .13);
+      z-index: 20;
+      display: flex;
+      justify-content: center;
+
+      &:hover {
+        cursor: pointer;
+      }
+    }
 
     &__information {
       padding: 8px 12px;

--- a/app/javascript/src/components/home-header.vue
+++ b/app/javascript/src/components/home-header.vue
@@ -16,14 +16,23 @@
       </div>
     </div>
     <div class="home-header__content">
-      <img
-        class="home-header__home-icon home-icon"
-        src="../assets/buenas-ideas.svg"
-      >
-      <img
-        class="home-header__home-icon home-icon-tablet"
-        src="../assets/buenas-ideas-mini.svg"
-      >
+      <router-link to="/">
+        <img
+          class="home-header__home-icon home-icon"
+          src="../assets/buenas-ideas.svg"
+        >
+        <img
+          class="home-header__home-icon home-icon-tablet"
+          src="../assets/buenas-ideas-mini.svg"
+        >
+      </router-link>
+    </div>
+    <div class="home-header__button-container">
+      <router-link to="/favorites">
+        <button class="home-header__button">
+          Ver mis favoritas
+        </button>
+      </router-link>
     </div>
   </div>
 </template>
@@ -94,11 +103,26 @@ export default {
       width: 100%;
     }
 
-    &__options {
+    &__button-container {
       position: absolute;
-      width: 100%;
-      right: 0;
-      top: 0;
+      right: 15px;
+      top: 15px;
+    }
+
+    &__button {
+      text-align: center;
+      background-color: $primary_color;
+      text-decoration: none;
+      height: 2.5em;
+      padding: 5px;
+      color: $white;
+      font-size: 15px;
+      margin-bottom: 3%;
+      border: 0;
+
+      &:hover {
+        cursor: pointer;
+      }
     }
 
     &__icon {

--- a/app/javascript/src/router.js
+++ b/app/javascript/src/router.js
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import VueRouter from 'vue-router';
 
 import HomeView from './views/home';
+import FavoritesView from './views/favorites';
 
 Vue.use(VueRouter);
 
@@ -9,6 +10,10 @@ const routes = [
   {
     path: '/',
     component: HomeView,
+  },
+  {
+    path: '/favorites',
+    component: FavoritesView,
   },
 ];
 

--- a/app/javascript/src/store/index.js
+++ b/app/javascript/src/store/index.js
@@ -1,12 +1,15 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import VuexPersistence from 'vuex-persist';
 
 import productsApi from '../api/products';
-import numberOfProducts from '../utils/numberOfProducts';
 
 Vue.use(Vuex);
 
-const LIMIT_PRICE_OFFSET_PERCENTAGE = 0.4;
+const vuexLocal = new VuexPersistence({
+  storage: window.localStorage,
+  reducer: (state) => ({ favoriteCategories: state.favoriteCategories }),
+});
 
 // eslint-disable-next-line new-cap
 const store = new Vuex.Store({
@@ -19,6 +22,7 @@ const store = new Vuex.Store({
     maxPrice: 30000,
     promoted: 4,
     nextPage: 1,
+    favoriteCategories: {},
   },
   mutations: {
     setCategory: (state, payload) => {
@@ -29,6 +33,14 @@ const store = new Vuex.Store({
     },
     setNextPage: (state, payload) => {
       state.nextPage = payload;
+    },
+    addFavoriteCategory: (state, payload) => {
+      Vue.set(state.favoriteCategories, payload.id, payload);
+    },
+    removeFavoriteCategory: (state, payload) => {
+      const { ...favoriteCategoriesCopy } = state.favoriteCategories;
+      delete favoriteCategoriesCopy[payload];
+      Vue.set(state, 'favoriteCategories', favoriteCategoriesCopy);
     },
   },
   actions: {
@@ -42,6 +54,7 @@ const store = new Vuex.Store({
       productsApi.markClicked(payload);
     },
   },
+  plugins: [vuexLocal.plugin],
 });
 
 export default store;

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -1,0 +1,204 @@
+<template>
+  <div class="home-container">
+    <home-header />
+    <div class="favorite-categories">
+      <div v-if="Object.keys(favoriteCategories).length === 0">
+        No tienes ninguna categoría favorita 😢
+      </div>
+      <div
+        v-for="(category, index) in favoriteCategories"
+        :key="index"
+      >
+        <div
+          class="favorite-category"
+          :class="{'favorite-category-container--last': index === favoriteCategories.length - 1}"
+        >
+          <div class="favorite-category__image-name-container">
+            <div class="favorite-category__image-container">
+              <img
+                class="favorite-category__image"
+                :src="category.products[1].imageUrl"
+              >
+            </div>
+            <div>
+              <div>{{ category.name | toUpper }}</div>
+              <div class="favorite-category__price">
+                ${{ category.products[0].price }} - ${{ category.products[category.products.length - 1].price }}
+              </div>
+            </div>
+          </div>
+          <div class="favorite-category__buttons-container">
+            <button
+              v-if="openCategory !== index"
+              @click="openCategory = index"
+              class="favorite-category__button"
+            >
+              Ver categoría
+            </button>
+            <button
+              v-else
+              @click="openCategory = -1"
+              class="favorite-category__button"
+            >
+              Ocultar
+            </button>
+            <button
+              class="favorite-category__button favorite-category__button--red"
+              @click="$store.commit('removeFavoriteCategory', category.id);"
+            >
+              Sacar de favoritos
+            </button>
+          </div>
+        </div>
+        <div class="favorite-category__preview">
+          <div
+            class="favorite-category__preview-card"
+            :class="{'favorite-category__preview-card--expanded': openCategory === index}"
+          >
+            <category
+              :category="category"
+              :hide-favorite-button="true"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import category from '../components/category';
+import HomeHeader from '../components/home-header';
+
+export default {
+  name: 'Favorites',
+  data() {
+    return {
+      openCategory: -1,
+    };
+  },
+  components: {
+    category,
+    HomeHeader,
+  },
+  computed: {
+    ...mapState([
+      'favoriteCategories',
+    ]),
+  },
+  filters: {
+    toUpper(value) {
+      return value.charAt(0).toUpperCase() + value.slice(1);
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+  @import '../../styles/variables';
+
+  .favorite-categories {
+    width: calc(min(90%, 700px));
+    display: flex;
+    flex-direction: column;
+    padding: 30px;
+    position: relative;
+    margin: 10px auto;
+    font-size: 1.2em;
+    color: $product-name-font-color;
+    border: 1px solid rgba(148, 148, 148, .16);
+    box-shadow: 0 2px 6px rgba(148, 148, 148, .24);
+    border-radius: 6px;
+    background-color: #fff;
+    padding-bottom: 40px;
+  }
+
+  .favorite-category {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+
+    @media(max-width: 640px) {
+      flex-direction: column;
+    }
+
+    &__image-name-container {
+      display: flex;
+      align-items: center;
+
+      @media(max-width: 640px) {
+        margin-bottom: 10px;
+      }
+    }
+
+    &__buttons-container {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+
+      @media(max-width: 640px) {
+        flex-direction: row;
+      }
+    }
+
+    &__image-container {
+      display: flex;
+      justify-content: center;
+      width: 150px;
+      height: 150px;
+      margin-right: 20px;
+    }
+
+    &__image {
+      object-fit: scale-down;
+      max-height: 100%;
+      max-width: 100%;
+    }
+
+    &__price {
+      color: #949494;
+      font-size: .8em;
+    }
+
+    &__button {
+      text-align: center;
+      background-color: $primary_color;
+      text-decoration: none;
+      height: 2.5em;
+      padding: 5px;
+      color: $white;
+      font-size: 15px;
+      margin-bottom: 3%;
+      border: 0;
+
+      &:hover {
+        cursor: pointer;
+      }
+
+      &--red {
+        background-color: $danger_color;
+      }
+
+      @media(max-width: 640px) {
+        margin-right: 20px;
+      }
+    }
+
+    &__preview {
+      overflow: hidden;
+    }
+
+    &__preview-card {
+      display: flex;
+      justify-content: center;
+      margin-top: -200%;
+      transition: all 1s;
+
+      &--expanded {
+        margin-top: 0;
+      }
+    }
+  }
+</style>

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -47,6 +47,7 @@ export default {
     ]),
   },
   mounted() {
+    this.$store.commit('setNextPage', 0);
     this.$store.dispatch('getProducts').then(() => {
       this.$store.loading = false;
     });
@@ -94,6 +95,7 @@ export default {
     font-size: $m-font-size;
     width: 100%;
     background: $home-background;
+    min-height: 100vh;
   }
 
   .home-products-container {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "vue-router": "^3.1.2",
     "vue-spinner": "^1.0.3",
     "vue-template-compiler": "^2.6.10",
-    "vuex": "^3.1.1"
+    "vuex": "^3.1.1",
+    "vuex-persist": "^2.2.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4957,6 +4957,11 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.template@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
@@ -8811,6 +8816,14 @@ vue@^2.6.10:
   version "2.6.11"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
+
+vuex-persist@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/vuex-persist/-/vuex-persist-2.2.0.tgz#4acec75562896b045c43d319690b93d6bc1b2bbc"
+  integrity sha512-o/qbBeMcKZZqMvCXc7kfIew/5cjHxlP1f53rx5YYp3r2tk2kxXYK/UZumxKn7OXywlurl2r0mgkuBzH6nIWFjw==
+  dependencies:
+    flatted "^2.0.0"
+    lodash.merge "^4.6.2"
 
 vuex@^3.1.1:
   version "3.5.1"


### PR DESCRIPTION
### Contexto
Los usuarios pueden ir viendo uno por uno las categorías que hay. Cuando una idea/categoría no les tinca, basta con que pasen a la siguiente. Si hay alguna que les gustó, no tienen como volver a encontrarla una vez que pasan de categoría.

### Qué se está haciendo
- Se agrega un botón en cada categoría para agregarlas a una lista de categoría de favoritas.
- Se agrega una vista con la lista de categorías que fueron marcadas como favoritas (esta vista es temporal, se supone que después vamos a diseñar otra)
![imagen](https://user-images.githubusercontent.com/26608673/92777919-0cd27b80-f377-11ea-82f1-fddd15b69288.png)
(Nota: en la imagen los colores se ven menos saturados, no sé por qué pasa eso 🤔) 