### PR TITLE
Tailwind Quickfix (missing character in import path)

### DIFF
--- a/app/javascript/packs/home.js
+++ b/app/javascript/packs/home.js
@@ -3,7 +3,7 @@ import router from '../src/router';
 import store from '../src/store/index';
 import app from '../src/app';
 
-import '..styles/application.css';
+import '../styles/application.css';
 
 document.addEventListener('DOMContentLoaded', () => {
   if (document.getElementById('home') !== null) {


### PR DESCRIPTION
### Contexto
El proyecto se estaba cayendo en heroku staging luego de agregar Tailwind al proyecto.

### Qué se está haciendo
Se corrige el import al css que contiene los imports de tailwind, donde faltaba un '/'. 