### PR TITLE
Feat/remove favorites confirmation

### DIFF
--- a/app/javascript/src/assets/cross.svg
+++ b/app/javascript/src/assets/cross.svg
@@ -1,0 +1,3 @@
+<svg class="fill-current text-black" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
+  <path d="M14.53 4.53l-1.06-1.06L9 7.94 4.53 3.47 3.47 4.53 7.94 9l-4.47 4.47 1.06 1.06L9 10.06l4.47 4.47 1.06-1.06L10.06 9z"></path>
+</svg>

--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -230,7 +230,7 @@ export default {
       padding: .1em;
       background-color: #fff;
       box-shadow: 0 4px 6px 0 rgba(43, 43, 43, .13);
-      z-index: 20;
+      z-index: 10;
       display: flex;
       justify-content: center;
 

--- a/app/javascript/src/components/home-header.vue
+++ b/app/javascript/src/components/home-header.vue
@@ -77,7 +77,7 @@ export default {
     background-color: $c-header-background;
     box-shadow: $box-shadow-header;
     padding: 2vh 0;
-    z-index: 100;
+    z-index: 20;
     align-items: center;
     border-radius: 0 0 16px 16px;
 

--- a/app/javascript/src/components/modal.vue
+++ b/app/javascript/src/components/modal.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="fixed w-full h-full top-0 left-0 flex items-center z-30 justify-center">
+  <div
+    class="transition-all duration-300 ease-in-out fixed w-full h-full top-0 left-0 flex items-center justify-center"
+    :class="{ 'opacity-0': !showModal, 'opacity-100': showModal, 'closed-modal': !showModal, 'z-30': showModal }"
+  >
     <div
       @click="close"
       class="absolute w-full h-full bg-gray-900 opacity-50"
@@ -42,8 +45,20 @@
   </div>
 </template>
 
+<style lang="scss">
+  .closed-modal {
+    z-index: -1;
+  }
+</style>
+
 <script>
 export default {
+  props: {
+    showModal: {
+      type: Boolean,
+      required: true,
+    },
+  },
   methods: {
     accept() {
       this.$emit('accept');

--- a/app/javascript/src/components/modal.vue
+++ b/app/javascript/src/components/modal.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="fixed w-full h-full top-0 left-0 flex items-center z-30 justify-center">
+    <div
+      @click="close"
+      class="absolute w-full h-full bg-gray-900 opacity-50"
+    />
+    <div class="bg-white w-11/12 md:max-w-md mx-auto rounded shadow-lg z-30 overflow-y-auto">
+      <div class="py-4 text-left px-6">
+        <div class="flex justify-between items-center pb-3">
+          <p class="text-2xl font-bold">
+            <slot name="title" />
+          </p>
+          <div
+            @click="close"
+            class="cursor-pointer"
+          >
+            <img
+              src="../assets/cross.svg"
+              alt="close-modal-cross"
+            >
+          </div>
+        </div>
+
+        <slot name="body" />
+
+        <div class="flex justify-end pt-2">
+          <button
+            @click="accept"
+            class="px-4 bg-transparent p-3 rounded-lg text-teal-500 hover:bg-gray-100 hover:text-teal-400 mr-2"
+          >
+            <slot name="accept-button-text" />
+          </button>
+          <button
+            @click="close"
+            class="px-4 bg-transparent p-3 rounded-lg text-teal-500 hover:bg-gray-100 hover:text-teal-400 mr-2"
+          >
+            <slot name="cancel-button-text" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {
+    accept() {
+      this.$emit('accept');
+    },
+    close() {
+      this.$emit('close');
+    },
+  },
+};
+</script>

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -46,19 +46,19 @@
             <button
               v-if="openCategory !== index"
               @click="openCategory = index"
-              class="favorite-category__button"
+              class="favorite-category__button favorite-category__button--left"
             >
               Ver categoría
             </button>
             <button
               v-else
               @click="openCategory = -1"
-              class="favorite-category__button"
+              class="favorite-category__button favorite-category__button--left"
             >
               Ocultar
             </button>
             <button
-              class="favorite-category__button favorite-category__button--red"
+              class="favorite-category__button favorite-category__button--red favorite-category__button--right"
               @click="openModal(category.id)"
             >
               Sacar de favoritos
@@ -197,7 +197,6 @@ export default {
       text-align: center;
       background-color: $primary_color;
       text-decoration: none;
-      height: 2.5em;
       padding: 5px;
       color: $white;
       font-size: 15px;
@@ -213,7 +212,13 @@ export default {
       }
 
       @media(max-width: 640px) {
-        margin-right: 20px;
+        &--left {
+          margin-right: 10px;
+        }
+
+        &--right {
+          margin-left: 10px;
+        }
       }
     }
 

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -1,6 +1,21 @@
 <template>
   <div class="home-container">
     <home-header />
+    <modal
+      v-if="modalIsOpen"
+      @accept="removeCategory"
+      @close="closeModal"
+    >
+      <template #body>
+        ¿De verdad quieres borrar esta categoría de tus favoritas?
+      </template>
+      <template #accept-button-text>
+        ¡Sí!
+      </template>
+      <template #cancel-button-text>
+        Mejor no
+      </template>
+    </modal>
     <div class="favorite-categories">
       <div v-if="Object.keys(favoriteCategories).length === 0">
         No tienes ninguna categoría favorita 😢
@@ -44,7 +59,7 @@
             </button>
             <button
               class="favorite-category__button favorite-category__button--red"
-              @click="$store.commit('removeFavoriteCategory', category.id);"
+              @click="openModal(category.id)"
             >
               Sacar de favoritos
             </button>
@@ -70,17 +85,21 @@
 import { mapState } from 'vuex';
 import category from '../components/category';
 import HomeHeader from '../components/home-header';
+import modal from '../components/modal';
 
 export default {
   name: 'Favorites',
   data() {
     return {
       openCategory: -1,
+      modalCategory: -1,
+      modalIsOpen: false,
     };
   },
   components: {
     category,
     HomeHeader,
+    modal,
   },
   computed: {
     ...mapState([
@@ -90,6 +109,19 @@ export default {
   filters: {
     toUpper(value) {
       return value.charAt(0).toUpperCase() + value.slice(1);
+    },
+  },
+  methods: {
+    closeModal() {
+      this.modalIsOpen = false;
+    },
+    openModal(categoryIndex) {
+      this.modalCategory = categoryIndex;
+      this.modalIsOpen = true;
+    },
+    removeCategory() {
+      this.modalIsOpen = false;
+      this.$store.commit('removeFavoriteCategory', this.modalCategory);
     },
   },
 };
@@ -103,7 +135,6 @@ export default {
     display: flex;
     flex-direction: column;
     padding: 30px;
-    position: relative;
     margin: 10px auto;
     font-size: 1.2em;
     color: $product-name-font-color;

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -2,7 +2,7 @@
   <div class="home-container">
     <home-header />
     <modal
-      v-if="modalIsOpen"
+      :show-modal="modalIsOpen"
       @accept="removeCategory"
       @close="closeModal"
     >


### PR DESCRIPTION
### Contexto
Una persona puede guardar o borrar las categorías de productos como favoritas, pero si las borran desde la vista de favoritos, no tienen forma de recuperarlas, excepto pasar por todas las categorías de nuevo.

### Qué se está haciendo
Se agrega una componente modal para agregar diálogos de confirmación en la aplicación.
Se está usando ese modal para que se confirme si de verdad se quiere borrar una categoría de favoritos.
No se muestra el diálogo en la página principal, porque ahí es fácil volver a agregarla si se equivocó, y el modal puede ser molesto si solo están probando la funcionalidad
Aproveché de arreglar un problema pequeño de presentación en la vista de favoritos

### Imagen de la feature
![imagen](https://user-images.githubusercontent.com/26608673/93248660-8945cf80-f766-11ea-952e-cf36ac85dadd.png)
