### PR TITLE
feat(categories): randomize categories order

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -1,6 +1,9 @@
 class Api::V1::CategoriesController < Api::V1::BaseController
+  before_action :set_random_seed, only: :index
+
   def index
-    category = Category.page(query_params[:page]).per(1)
+    category = Category.randomized(session[:seed]).page(query_params[:page]).per(1)
+    get_new_seed unless category.next_page
     respond_with category, meta: {
       next_page: category.next_page
     }
@@ -8,5 +11,14 @@ class Api::V1::CategoriesController < Api::V1::BaseController
 
   def query_params
     params.permit(:page)
+  end
+
+  def set_random_seed
+    get_new_seed unless session[:seed]
+  end
+
+  def get_new_seed
+    srand
+    session[:seed] = rand(-1.0...1.0)
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,6 +3,11 @@ class Category < ApplicationRecord
 
   validates :name, presence: true
   validates :description, presence: true
+
+  def self.randomized(seed = 0.0)
+    connection.execute(Arel.sql("SELECT SETSEED(#{seed})"))
+    order(Arel.sql('RANDOM()'))
+  end
 end
 
 # == Schema Information


### PR DESCRIPTION
### Contexto
Los productos, que ahora se muestran por categoría, aparecen siempre en el mismo orden.
Esto es indeseable, porque las categorías que están primero en la base de datos siempre aparecen antes, y por lo tanto es posible que hayan categorías que nadie (o muy poca gente) vea.
Tampoco queremos que una persona se meta dos veces a la página y vea exactamente lo mismo, para que siga usándola.
En el futuro queremos agregar una pantalla que diga "Buscando tu próximo regalo" (o algo así) con un delay artificial, y el orden random ayuda a crear ese efecto.

### Qué es está haciendo
Se guarda una semilla al azar en la sesión. Esta semilla se usa para ordenar las categorías en un orden random, y para ir mostrándolas en ese orden, hasta que ya se han visto todas. Cuando se han visto todas, las categorías se vuelven a "barajar", y el ciclo se repite.

Esto tiene una limitación, y es que la última categoría puede coincidir con la primera de la siguiente baraja, pero eso no es tan fácil de arreglar, ni va a ser tan probable cuando tengamos más categorías.