### PR TITLE
Feat/add product confirmation text

### DIFF
--- a/app/assets/stylesheets/stores/_store_new_product.scss
+++ b/app/assets/stylesheets/stores/_store_new_product.scss
@@ -128,8 +128,8 @@ $title-font: #353434;
   }
 
   &__link {
-    width: 129px;
-    height: 30px;
+    width: 136px;
+    height: 40px;
     padding: 5px;
     background-color: $primary_color;
     color: $white;

--- a/app/assets/stylesheets/stores/_store_new_product.scss
+++ b/app/assets/stylesheets/stores/_store_new_product.scss
@@ -9,7 +9,7 @@ $title-font: #353434;
   margin-left: 30px;
 }
 
-.form-description {
+.form-text {
   margin-left: 30px;
   margin-right: 30px;
 }

--- a/app/controllers/stores/catalog_controller.rb
+++ b/app/controllers/stores/catalog_controller.rb
@@ -6,6 +6,7 @@ class Stores::CatalogController < ApplicationController
 
   def create
     add_product
+    flash[:success] = true
     redirect_to new_stores_catalog_path
   end
 

--- a/app/javascript/stores/components/easy-product-form.vue
+++ b/app/javascript/stores/components/easy-product-form.vue
@@ -97,11 +97,9 @@
       <div class="button-container">
         <a
           href="/#"
-          class="btn product-input__link product-input__link--cancel"
+          class="flex items-center justify-center btn product-input__link product-input__link--cancel"
         >
-          <div class="link-button-text">
-            VOLVER
-          </div>
+          VOLVER
         </a>
         <button
           type="submit"

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -5,7 +5,7 @@ class Product < ApplicationRecord
 
   has_one_attached :image
   belongs_to :store
-  belongs_to :category
+  belongs_to :category, optional: true
   has_many :product_actions, dependent: :destroy
 
   validates :name, presence: true, length: { minimum: 5 }

--- a/app/views/stores/catalog/new.html.erb
+++ b/app/views/stores/catalog/new.html.erb
@@ -1,3 +1,9 @@
 <h1 class="form-title">Agregar producto</h1>
-<p class="form-description">Sube tus productos gratis. Una vez aprobados serán mostrados a nuestros miles de usuarios.</p>
+<p class="form-text">Sube tus productos gratis. Una vez aprobados serán mostrados a nuestros miles de usuarios.</p>
+<% if flash[:success] %>
+  <p class="text-teal-500 font-bold form-text">
+    ¡Producto agregado correctamente! Recuerda que debe ser aprobado para que aparezca en la página
+  </p>
+<% end %>
+
 <easy-product-form />

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,7 +12,7 @@ Region.find_or_create_by(name: 'Chile')
 Region.find_or_create_by(name: 'Brasil')
 Region.find_or_create_by(name: 'Argentina')
 
-Store.create(region_id: 1, name: 'TestStore', email: 'test@gmail.com', password: '12345678', password_confirmation: '12345678')
+Store.create(region_id: 1, name: 'TestStore', email: 'contacto@platan.us', password: '12345678', password_confirmation: '12345678')
 
 coffee_makers = Category.find_or_create_by(name: 'cafeteras', description: 'máquinas para hacer café')
 coffee = Product.find_or_create_by(name: 'Cafetera Francesa', store_id: 1, price: 4990, link:'https://www.facebook.com/', clicks_cost: 20, category: coffee_makers, email: 'dummy@example.com', status: :approved)

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Product, type: :model do
   end
 
   describe 'associations' do
-    it { is_expected.to belong_to(:category) }
+    it { is_expected.to belong_to(:category).optional }
   end
 
   describe 'product states with image' do


### PR DESCRIPTION
- Se arregla un bug al crear nuevos productos: como la categoría se elige al aprobarlos, la relación belongs_to es opcional.
- Se agregó un texto de confirmación tras agregar un nuevo producto
- Se arregla el tamaño del botón "volver" en el formulario, y se centra correctamente su texto