### PR TITLE
feat(carousel): add slider/carousel for product-card

### DIFF
--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -35,20 +35,36 @@
         </p>
       </div>
     </div>
-    <div
-      class="flex flex-wrap justify-center my-6"
+    <div>
+      <vueper-slides
+        ref="productSlider"
+        class="my-6 no-shadow"
+        fixed-height="230px"
+        prevent-yscroll
+        :arrows="false"
+        :bullets="false"
+        :dragging-distance="70"
+        :infinite="false"
+        :init-slide="2"
+        :visible-slides="3"
+        @next="changeProduct(selectedProductIndex + 1)"
+        @previous="changeProduct(selectedProductIndex - 1)"
     >
-      <div
+        <vueper-slide
         v-for="(product, index) in category.products"
         :key="index"
         class="flex category__product"
         :class="{'category__product--selected': index === selectedProductIndex }"
-        @click="changeProduct(index)"
+          @click.native="changeProduct(index); $refs.productSlider.goToSlide(index);"
       >
+          <template v-slot:content>
         <product-card
           :product="product"
           v-bind="{ highlight : index === 1 }"
         />
+          </template>
+        </vueper-slide>
+      </vueper-slides>
       </div>
     </div>
   </div>
@@ -56,6 +72,9 @@
 
 <script>
 import { mapActions, mapState } from 'vuex';
+import { VueperSlides, VueperSlide } from 'vueperslides';
+import 'vueperslides/dist/vueperslides.css';
+
 import convertToClp from '../utils/convert-to-clp';
 
 import productCard from './product-card';
@@ -63,6 +82,8 @@ import productCard from './product-card';
 export default {
   components: {
     productCard,
+    VueperSlides,
+    VueperSlide,
   },
   data() {
     return {
@@ -224,4 +245,16 @@ export default {
       background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 61%, rgba(0, 0, 0, .45) 100%);
     }
   }
+
+  .vueperslide {
+    &--visible {
+      opacity: .6;
+    }
+
+    &--active {
+      opacity: 1;
+      transition: opacity .2s ease-in-out;
+    }
+  }
+
 </style>

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -1,10 +1,10 @@
 <template>
   <div
-    class="flex flex-col w-full mx-1 bg-white border border-gray-100 border-solid rounded-sm shadow-md"
-    :class="{ 'border-primary' : highlight, 'mt-4' : !highlight }"
+    class="flex flex-col w-full mx-1 mb-4 bg-white border border-gray-100 border-solid rounded-sm shadow-md"
+    :class="{ 'border-primary' : highlight, 'mt-5' : !highlight }"
   >
     <div
-      class="w-full text-xs text-left text-white bg-primary"
+      class="w-full h-5 text-xs text-left text-white bg-primary"
       v-if="highlight"
     >
       <span class="ml-2">Regalo popular</span>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "vue-router": "^3.1.2",
     "vue-spinner": "^1.0.3",
     "vue-template-compiler": "^2.6.10",
+    "vueperslides": "^2.10.8",
     "vuex": "^3.1.1",
     "vuex-persist": "^2.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8997,6 +8997,11 @@ vue@^2.6.10:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
 
+vueperslides@^2.10.8:
+  version "2.10.8"
+  resolved "https://registry.yarnpkg.com/vueperslides/-/vueperslides-2.10.8.tgz#7ceae734252320e74e5f112cdcd6ba45e0e8d438"
+  integrity sha512-hMNO3zeG8AuK/yp+DKgeCbjqTLLePOm+PlCBjoVk0vtEWuxKRTcptEdNxF7J4qncefLpZHEGj1v7t/Or7TSPbw==
+
 vuex-persist@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/vuex-persist/-/vuex-persist-2.2.0.tgz#4acec75562896b045c43d319690b93d6bc1b2bbc"


### PR DESCRIPTION
### Contexto
No es posible ver mucha info de los regalos que están disponibles o de las alternativas que hay para una misma categoría. Necesitamos que el usuario pueda explorar las categorías que hay y los productos que tienen para aumentar la posibilidades de generar un click.

### Qué se está haciendo
- Se agrega VueperSlides, donde ahora las product-cards son slides, para recorrer los productos de una categoría en forma de carrusel.
- Se cambian algunas clases de css para mantener el diseño con los nuevos atributos de VueperSlides.
-----------
#### Info adicional
- La idea original es que la slide activa quede centrada, lo cual solo ocurre para las slides interiores (cualquiera menos la primera y la última) por cómo funciona VueperSlides. Aún se están evaluando soluciones.
- Queda pendiente darle más énfasis al producto seleccionado.


![Peek 22-09-2020 09-17](https://user-images.githubusercontent.com/1688697/93890535-d07d1480-fcc0-11ea-88ba-922eabbeb326.gif)