### PR TITLE
Feat/carousel: Replace vueperslides with vueSlickCarousel

### DIFF
--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -36,43 +36,38 @@
       </div>
     </div>
     <div>
-      <vueper-slides
-        ref="productSlider"
-        class="my-6 no-shadow"
-        fixed-height="230px"
-        prevent-yscroll
+      <vueSlickCarousel
+        class="mt-3"
         :arrows="false"
-        :bullets="false"
-        :dragging-distance="70"
-        :infinite="false"
-        :init-slide="2"
-        :visible-slides="3"
-        @next="changeProduct(selectedProductIndex + 1)"
-        @previous="changeProduct(selectedProductIndex - 1)"
+        :center-mode="true"
+        :center-padding="0"
+        :focus-on-select="true"
+        :initial-slide="1"
+        :slides-to-show="3"
+        :swipe-to-slide="true"
+        @beforeChange="changeProduct"
       >
-        <vueper-slide
+        <div
           v-for="(product, index) in category.products"
           :key="index"
           class="flex category__product"
           :class="{'category__product--selected': index === selectedProductIndex }"
-          @click.native="changeProduct(index); $refs.productSlider.goToSlide(index);"
         >
-          <template v-slot:content>
-            <product-card
-              :product="product"
-              v-bind="{ highlight : index === 1 }"
-            />
-          </template>
-        </vueper-slide>
-      </vueper-slides>
+          <product-card
+            :product="product"
+            v-bind="{ highlight : index === 1 }"
+          />
+        </div>
+      </vueSlickCarousel>
     </div>
   </div>
 </template>
 
 <script>
 import { mapActions, mapState } from 'vuex';
-import { VueperSlides, VueperSlide } from 'vueperslides';
-import 'vueperslides/dist/vueperslides.css';
+
+import VueSlickCarousel from 'vue-slick-carousel';
+import 'vue-slick-carousel/dist/vue-slick-carousel.css';
 
 import convertToClp from '../utils/convert-to-clp';
 
@@ -81,8 +76,7 @@ import productCard from './product-card';
 export default {
   components: {
     productCard,
-    VueperSlides,
-    VueperSlide,
+    VueSlickCarousel,
   },
   data() {
     return {
@@ -245,15 +239,16 @@ export default {
     }
   }
 
-  .vueperslide {
-    &--visible {
-      opacity: .6;
+  .slick {
+    &-slide {
+      opacity: .65;
+      transform: scale(.9);
+      transition: transform .2s ease-in-out, opacity .2s ease-in-out;
     }
 
-    &--active {
+    &-current {
       opacity: 1;
-      transition: opacity .2s ease-in-out;
+      transform: scale(1);
     }
   }
-
 </style>

--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -92,8 +92,8 @@ export default {
       this.markClicked(this.selectedProduct.id);
       window.open(this.selectedProduct.link, '_blank');
     },
-    changeProduct(index) {
-      this.selectedProductIndex = index;
+    changeProduct(oldSlideIndex, newSlideIndex) {
+      this.selectedProductIndex = newSlideIndex;
     },
     setLikeStatus() {
       if (this.isLiked) {

--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -80,7 +80,7 @@ export default {
   },
   data() {
     return {
-      selectedProductIndex: 0,
+      selectedProductIndex: 1,
       products: [],
     };
   },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "vue-slick-carousel": "^1.0.6",
     "vue-spinner": "^1.0.3",
     "vue-template-compiler": "^2.6.10",
-    "vueperslides": "^2.10.8",
     "vuex": "^3.1.1",
     "vuex-persist": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "vue": "^2.6.10",
     "vue-loader": "^15.7.1",
     "vue-router": "^3.1.2",
+    "vue-slick-carousel": "^1.0.6",
     "vue-spinner": "^1.0.3",
     "vue-template-compiler": "^2.6.10",
     "vueperslides": "^2.10.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9048,11 +9048,6 @@ vue@^2.6.10:
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.11.tgz#76594d877d4b12234406e84e35275c6d514125c5"
   integrity sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==
 
-vueperslides@^2.10.8:
-  version "2.10.8"
-  resolved "https://registry.yarnpkg.com/vueperslides/-/vueperslides-2.10.8.tgz#7ceae734252320e74e5f112cdcd6ba45e0e8d438"
-  integrity sha512-hMNO3zeG8AuK/yp+DKgeCbjqTLLePOm+PlCBjoVk0vtEWuxKRTcptEdNxF7J4qncefLpZHEGj1v7t/Or7TSPbw==
-
 vuex-persist@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/vuex-persist/-/vuex-persist-2.2.0.tgz#4acec75562896b045c43d319690b93d6bc1b2bbc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3069,6 +3069,11 @@ enhanced-resolve@^4.1.1, enhanced-resolve@^4.3.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+enquire.js@2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/enquire.js/-/enquire.js-2.1.6.tgz#3e8780c9b8b835084c3f60e166dbc3c2a3c89814"
+  integrity sha1-PoeAybi4NQhMP2DhZtvDwqPImBQ=
+
 entities@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
@@ -4834,6 +4839,13 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
+json2mq@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/json2mq/-/json2mq-0.2.0.tgz#b637bd3ba9eabe122c83e9720483aeb10d2c904a"
+  integrity sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=
+  dependencies:
+    string-convert "^0.2.0"
+
 json3@^3.3.2:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.3.tgz#7fc10e375fc5ae42c4705a5cc0aa6f62be305b81"
@@ -5009,7 +5021,17 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
-lodash.get@^4.0:
+lodash.assign@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
+  integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
+lodash.get@^4.0, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -5028,6 +5050,11 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.pick@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+  integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
 
 lodash.template@^4.5.0:
   version "4.5.0"
@@ -7425,6 +7452,11 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+resize-observer-polyfill@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"
+  integrity sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==
+
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
@@ -8064,6 +8096,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+string-convert@^0.2.0:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/string-convert/-/string-convert-0.2.1.tgz#6982cc3049fbb4cd85f8b24568b9d9bf39eeff97"
+  integrity sha1-aYLMMEn7tM2F+LJFaLnZvznu/5c=
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -8965,6 +9002,20 @@ vue-router@^3.1.2:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.3.tgz#fa93768616ee338aa174f160ac965167fa572ffa"
   integrity sha512-BADg1mjGWX18Dpmy6bOGzGNnk7B/ZA0RxuA6qedY/YJwirMfKXIDzcccmHbQI0A6k5PzMdMloc0ElHfyOoX35A==
+
+vue-slick-carousel@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/vue-slick-carousel/-/vue-slick-carousel-1.0.6.tgz#8fbfe59a233b0fb7777e4934b60bbdf0a6a24f96"
+  integrity sha512-1CN/hpWC8m1U/eO7Kuc71jntJqdg6Z/ieLji21OPfQUhs8ZYnnGhQSu1covpa3IyuovM9T5puPCVgexs3DDF5A==
+  dependencies:
+    enquire.js "2.1.6"
+    json2mq "0.2.0"
+    lodash.assign "^4.2.0"
+    lodash.debounce "^4.0.8"
+    lodash.get "^4.4.2"
+    lodash.pick "^4.4.0"
+    resize-observer-polyfill "1.5.1"
+    vue "^2.6.10"
 
 vue-spinner@^1.0.3:
   version "1.0.4"


### PR DESCRIPTION
### Contexto
No es posible ver mucha info de los regalos que están disponibles o de las alternativas que hay para una misma categoría. Necesitamos que el usuario pueda explorar las categorías que hay y los productos que tienen para aumentar la posibilidades de generar un click. 
Se había optado por usar vueperslides como carrusel, pero quedó chico.

### Que se está haciendo
- Se reemplaza vueperslides con vueSlickCarousel
- Se corrige el método changeProduct para recibir los parámetros del event beforeChange de vueSlickCarousel
- Se corrige el valor por defecto de selectedProductIndex para coincidir con el slide inicial de vueSlickCarousel
