### PR TITLE
Replace favorite categories by favorite products

### DIFF
--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -97,9 +97,9 @@ export default {
     },
     setLikeStatus() {
       if (this.isLiked) {
-        this.$store.commit('removeFavoriteCategory', this.category.id);
+        this.$store.commit('removeFavoriteProduct', this.selectedProduct.id);
       } else {
-        this.$store.commit('addFavoriteCategory', this.category);
+        this.$store.commit('addFavoriteProduct', this.selectedProduct);
       }
     },
   },
@@ -115,10 +115,10 @@ export default {
   },
   computed: {
     ...mapState([
-      'favoriteCategories',
+      'favoriteProducts',
     ]),
     isLiked() {
-      return this.category.id in this.favoriteCategories;
+      return this.selectedProduct.id in this.favoriteProducts;
     },
     selectedProduct() {
       return this.category.products[this.selectedProductIndex];

--- a/app/javascript/src/store/index.js
+++ b/app/javascript/src/store/index.js
@@ -8,7 +8,7 @@ Vue.use(Vuex);
 
 const vuexLocal = new VuexPersistence({
   storage: window.localStorage,
-  reducer: (state) => ({ favoriteCategories: state.favoriteCategories }),
+  reducer: (state) => ({ favoriteProducts: state.favoriteProducts }),
 });
 
 // eslint-disable-next-line new-cap
@@ -22,7 +22,7 @@ const store = new Vuex.Store({
     maxPrice: 30000,
     promoted: 4,
     nextPage: 1,
-    favoriteCategories: {},
+    favoriteProducts: {},
   },
   mutations: {
     setCategory: (state, payload) => {
@@ -34,13 +34,13 @@ const store = new Vuex.Store({
     setNextPage: (state, payload) => {
       state.nextPage = payload;
     },
-    addFavoriteCategory: (state, payload) => {
-      Vue.set(state.favoriteCategories, payload.id, payload);
+    addFavoriteProduct: (state, payload) => {
+      Vue.set(state.favoriteProducts, payload.id, payload);
     },
-    removeFavoriteCategory: (state, payload) => {
-      const { ...favoriteCategoriesCopy } = state.favoriteCategories;
-      delete favoriteCategoriesCopy[payload];
-      Vue.set(state, 'favoriteCategories', favoriteCategoriesCopy);
+    removeFavoriteProduct: (state, payload) => {
+      const { ...favoriteProductsCopy } = state.favoriteProducts;
+      delete favoriteProductsCopy[payload];
+      Vue.set(state, 'favoriteProducts', favoriteProductsCopy);
     },
   },
   actions: {

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -3,11 +3,11 @@
     <home-header />
     <modal
       :show-modal="modalIsOpen"
-      @accept="removeCategory"
+      @accept="removeProduct"
       @close="closeModal"
     >
       <template #body>
-        ¿De verdad quieres borrar esta categoría de tus favoritas?
+        ¿De verdad quieres borrar este producto de tus favoritos?
       </template>
       <template #accept-button-text>
         ¡Sí!
@@ -17,28 +17,28 @@
       </template>
     </modal>
     <div class="favorite-categories">
-      <div v-if="Object.keys(favoriteCategories).length === 0">
-        No tienes ninguna categoría favorita 😢
+      <div v-if="Object.keys(favoriteProducts).length === 0">
+        No tienes ningún producto favorito 😢
       </div>
       <div
-        v-for="(category, index) in favoriteCategories"
+        v-for="(product, index) in favoriteProducts"
         :key="index"
       >
         <div
           class="favorite-category"
-          :class="{'favorite-category-container--last': index === favoriteCategories.length - 1}"
+          :class="{'favorite-category-container--last': index === favoriteProducts.length - 1}"
         >
           <div class="favorite-category__image-name-container">
             <div class="favorite-category__image-container">
               <img
                 class="favorite-category__image"
-                :src="category.products[1].imageUrl"
+                :src="product.imageUrl"
               >
             </div>
             <div>
-              <div>{{ category.name | toUpper }}</div>
+              <div>{{ product.name | toUpper }}</div>
               <div class="favorite-category__price">
-                ${{ category.products[0].price }} - ${{ category.products[category.products.length - 1].price }}
+                ${{ product.price }}
               </div>
             </div>
           </div>
@@ -59,7 +59,7 @@
             </button>
             <button
               class="favorite-category__button favorite-category__button--red favorite-category__button--right"
-              @click="openModal(category.id)"
+              @click="openModal(product.id)"
             >
               Sacar de favoritos
             </button>
@@ -92,7 +92,7 @@ export default {
   data() {
     return {
       openCategory: -1,
-      modalCategory: -1,
+      modalProduct: -1,
       modalIsOpen: false,
     };
   },
@@ -103,7 +103,7 @@ export default {
   },
   computed: {
     ...mapState([
-      'favoriteCategories',
+      'favoriteProducts',
     ]),
   },
   filters: {
@@ -115,13 +115,13 @@ export default {
     closeModal() {
       this.modalIsOpen = false;
     },
-    openModal(categoryIndex) {
-      this.modalCategory = categoryIndex;
+    openModal(productIndex) {
+      this.modalProduct = productIndex;
       this.modalIsOpen = true;
     },
-    removeCategory() {
+    removeProduct() {
       this.modalIsOpen = false;
-      this.$store.commit('removeFavoriteCategory', this.modalCategory);
+      this.$store.commit('removeFavoriteProduct', this.modalProduct);
     },
   },
 };

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -16,7 +16,7 @@
         Mejor no
       </template>
     </modal>
-    <div class="favorite-categories">
+    <div class="favorite-products">
       <div v-if="Object.keys(favoriteProducts).length === 0">
         No tienes ningún producto favorito 😢
       </div>
@@ -25,50 +25,50 @@
         :key="index"
       >
         <div
-          class="favorite-category"
-          :class="{'favorite-category-container--last': index === favoriteProducts.length - 1}"
+          class="favorite-product"
+          :class="{'favorite-product-container--last': index === favoriteProducts.length - 1}"
         >
-          <div class="favorite-category__image-name-container">
-            <div class="favorite-category__image-container">
+          <div class="favorite-product__image-name-container">
+            <div class="favorite-product__image-container">
               <img
-                class="favorite-category__image"
+                class="favorite-product__image"
                 :src="product.imageUrl"
               >
             </div>
             <div>
               <div>{{ product.name | toUpper }}</div>
-              <div class="favorite-category__price">
+              <div class="favorite-product__price">
                 ${{ product.price }}
               </div>
             </div>
           </div>
-          <div class="favorite-category__buttons-container">
+          <div class="favorite-product__buttons-container">
             <button
               v-if="openCategory !== index"
               @click="openCategory = index"
-              class="favorite-category__button favorite-category__button--left"
+              class="favorite-product__button favorite-product__button--left"
             >
               Ver categoría
             </button>
             <button
               v-else
               @click="openCategory = -1"
-              class="favorite-category__button favorite-category__button--left"
+              class="favorite-product__button favorite-product__button--left"
             >
               Ocultar
             </button>
             <button
-              class="favorite-category__button favorite-category__button--red favorite-category__button--right"
+              class="favorite-product__button favorite-product__button--red favorite-product__button--right"
               @click="openModal(product.id)"
             >
               Sacar de favoritos
             </button>
           </div>
         </div>
-        <div class="favorite-category__preview">
+        <div class="favorite-product__preview">
           <div
-            class="favorite-category__preview-card"
-            :class="{'favorite-category__preview-card--expanded': openCategory === index}"
+            class="favorite-product__preview-card"
+            :class="{'favorite-product__preview-card--expanded': openCategory === index}"
           >
             <category
               :category="category"
@@ -130,7 +130,7 @@ export default {
 <style lang="scss" scoped>
   @import '../../styles/variables';
 
-  .favorite-categories {
+  .favorite-products {
     width: calc(min(90%, 700px));
     display: flex;
     flex-direction: column;
@@ -145,7 +145,7 @@ export default {
     padding-bottom: 40px;
   }
 
-  .favorite-category {
+  .favorite-product {
     display: flex;
     flex-direction: row;
     justify-content: space-between;


### PR DESCRIPTION
### Contexto

Actualmente se permite guardar categorías en favoritos, pero para acceder nuevamente a los productos se necesita entrar a la categoría nuevamente, por lo que es mejor idea guardar productos individuales en favoritos.

### Qué se está haciendo

- Se reemplaza la lógica de favoriteCategories por la de favoriteProducts
- Se cambia el nombre de las clases en la favorites view para concordar con esta nueva lógica

#### Info adicional
- 'Ver categoría' ya no funciona, pero la acción principal será 'Ver producto', que queda pendiente por ahora.
- Este cambio es necesario en medio de la implementación de la vista desktop, y gran parte del componente 'category' cambiará posterior a este PR.
