### PR TITLE
Feat/desktop view

### DIFF
--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -22,6 +22,7 @@
           <product-card
             :product="product"
             v-bind="{ highlight : index === 1 }"
+            :category="category"
           />
         </div>
       </vueSlickCarousel>

--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -4,21 +4,20 @@
   >
     <div>
       <vueSlickCarousel
-        class="mt-3"
+        class="w-full mt-8"
         :arrows="false"
         :center-mode="true"
         :center-padding="0"
-        :focus-on-select="true"
+        :fade="true"
         :initial-slide="1"
-        :slides-to-show="3"
+        :slides-to-show="1"
         :swipe-to-slide="true"
         @beforeChange="changeProduct"
       >
         <div
           v-for="(product, index) in category.products"
           :key="index"
-          class="flex category__product"
-          :class="{'category__product--selected': index === selectedProductIndex }"
+          class="flex"
         >
           <product-card
             :product="product"
@@ -108,92 +107,6 @@ export default {
   }
 
   .category {
-    width: calc(min(100%, 700px));
-
-    &__product {
-      flex-basis: calc(33%);
-
-      &:hover {
-        cursor: pointer;
-        filter: brightness(90%);
-      }
-
-      &--selected {
-        border-color: $primary-color;
-        filter: brightness(90%);
-      }
-    }
-
-    &__product-selector {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: center;
-      max-width: 300px;
-      margin: auto;
-    }
-  }
-
-  .product-card {
-    display: flex;
-    flex-direction: column;
-    height: 100%;
-    position: relative;
-    margin: auto;
-    font-size: 1.2em;
-    color: $product-name-font-color;
-    border: 1px solid rgba(148, 148, 148, .16);
-    box-shadow: 0 2px 6px rgba(148, 148, 148, .24);
-    border-radius: 6px;
-    background-color: #fff;
-
-    &__icon {
-      width: 80%;
-      height: 80%;
-      margin: .17em;
-      cursor: pointer;
-
-      &--active {
-        animation: pump 6s;
-        animation-iteration-count: infinite;
-      }
-    }
-
-    &__icon-container {
-      position: absolute;
-      top: 8px;
-      right: 8px;
-      height: 1.5em;
-      width: 1.5em;
-      border-radius: 50%;
-      padding: .1em;
-      background-color: #fff;
-      box-shadow: 0 4px 6px 0 rgba(43, 43, 43, .13);
-      z-index: 10;
-      display: flex;
-      justify-content: center;
-
-      &:hover {
-        cursor: pointer;
-      }
-    }
-  }
-
-  .selected-product {
-    &__gradient {
-      background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0) 61%, rgba(0, 0, 0, .45) 100%);
-    }
-  }
-
-  .slick {
-    &-slide {
-      opacity: .65;
-      transform: scale(.9);
-      transition: transform .2s ease-in-out, opacity .2s ease-in-out;
-    }
-
-    &-current {
-      opacity: 1;
-      transform: scale(1);
-    }
+    width: calc(min(100%, 900px));
   }
 </style>

--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -2,39 +2,6 @@
   <div
     class="flex flex-col m-auto category"
   >
-    <div
-      class="relative"
-    >
-      <div
-        v-if="!hideFavoriteButton"
-        class="product-card__icon-container"
-        @click="setLikeStatus"
-      >
-        <img
-          v-if="isLiked"
-          class="product-card__icon product-card__icon--active"
-          src="../assets/like-color-badge.svg"
-        >
-        <img
-          v-else
-          class="product-card__icon"
-          src="../assets/like-badge.svg"
-        >
-      </div>
-      <img
-        class="flex object-cover w-full h-56"
-        :src="selectedProduct.imageUrl"
-      >
-      <div
-        class="absolute top-0 block w-full h-full selected-product__gradient"
-      >
-        <p
-          class="absolute bottom-0 px-3 py-2 text-xl font-bold text-white"
-        >
-          {{ selectedProduct.name }}
-        </p>
-      </div>
-    </div>
     <div>
       <vueSlickCarousel
         class="mt-3"
@@ -64,8 +31,6 @@
 </template>
 
 <script>
-import { mapActions, mapState } from 'vuex';
-
 import VueSlickCarousel from 'vue-slick-carousel';
 import 'vue-slick-carousel/dist/vue-slick-carousel.css';
 
@@ -85,22 +50,8 @@ export default {
     };
   },
   methods: {
-    ...mapActions([
-      'markClicked',
-    ]),
-    clickAction() {
-      this.markClicked(this.selectedProduct.id);
-      window.open(this.selectedProduct.link, '_blank');
-    },
     changeProduct(oldSlideIndex, newSlideIndex) {
       this.selectedProductIndex = newSlideIndex;
-    },
-    setLikeStatus() {
-      if (this.isLiked) {
-        this.$store.commit('removeFavoriteProduct', this.selectedProduct.id);
-      } else {
-        this.$store.commit('addFavoriteProduct', this.selectedProduct);
-      }
     },
   },
   props: {
@@ -114,12 +65,6 @@ export default {
     },
   },
   computed: {
-    ...mapState([
-      'favoriteProducts',
-    ]),
-    isLiked() {
-      return this.selectedProduct.id in this.favoriteProducts;
-    },
     selectedProduct() {
       return this.category.products[this.selectedProductIndex];
     },

--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -4,6 +4,7 @@
   >
     <div>
       <vueSlickCarousel
+        ref="slider"
         class="w-full mt-8"
         :arrows="false"
         :center-mode="true"
@@ -23,6 +24,7 @@
             :product="product"
             v-bind="{ highlight : index === 1 }"
             :category="category"
+            @change-slide="changeSlide"
           />
         </div>
       </vueSlickCarousel>
@@ -52,6 +54,9 @@ export default {
   methods: {
     changeProduct(oldSlideIndex, newSlideIndex) {
       this.selectedProductIndex = newSlideIndex;
+    },
+    changeSlide(index) {
+      this.$refs.slider.goTo(index);
     },
   },
   props: {

--- a/app/javascript/src/components/home-header.vue
+++ b/app/javascript/src/components/home-header.vue
@@ -1,35 +1,37 @@
 <template>
   <div
-    class="home-header"
+    class="sticky top-0 z-20 grid items-center w-full h-16 grid-cols-3 mx-auto bg-white shadow-md"
   >
-    <div class="store-elements-container">
+    <div class="flex items-center h-full ml-3 cursor-pointer text-primary">
       <img
-        class="home-header__icon home-header__icon--first"
+        class="block"
         src="../assets/store.svg"
         @click="goToStore"
       >
       <div
-        class="home-header__store-text"
+        class="my-auto ml-1 text-sm"
         @click="goToStore"
       >
         Vende tus productos
       </div>
     </div>
-    <div class="home-header__content">
+    <div class="h-full mt-1">
       <router-link to="/">
         <img
-          class="home-header__home-icon home-icon"
+          class="hidden h-12 mx-auto sm:block"
           src="../assets/buenas-ideas.svg"
         >
         <img
-          class="home-header__home-icon home-icon-tablet"
+          class="mx-auto sm:hidden"
           src="../assets/buenas-ideas-mini.svg"
         >
       </router-link>
     </div>
-    <div class="home-header__button-container">
+    <div class="mr-3 text-right">
       <router-link to="/favorites">
-        <button class="home-header__button">
+        <button
+          class="h-8 px-3 my-auto text-base border border-solid rounded-sm text-primary border-primary hover:bg-primary hover:text-white"
+        >
           Ver mis favoritas
         </button>
       </router-link>
@@ -67,162 +69,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss">
-  @import '../../styles/variables';
-
-  .home-header {
-    position: sticky;
-    top: 0;
-    background-color: $c-header-background;
-    box-shadow: $box-shadow-header;
-    padding: 2vh 0;
-    z-index: 20;
-    align-items: center;
-    border-radius: 0 0 16px 16px;
-
-    &__store-text {
-      font-size: .9em;
-      align-self: center;
-      color: $label-color;
-
-      &:hover {
-        cursor: pointer;
-        text-decoration: underline;
-      }
-    }
-
-    &__content {
-      margin: 0 auto;
-      width: $m-width-grid;
-      position: relative;
-    }
-
-    &__home-icon {
-      height: 3em;
-      width: 100%;
-    }
-
-    &__button-container {
-      position: absolute;
-      right: 15px;
-      top: 15px;
-    }
-
-    &__button {
-      text-align: center;
-      background-color: $primary_color;
-      text-decoration: none;
-      height: 2.5em;
-      padding: 5px;
-      color: $white;
-      font-size: 15px;
-      margin-bottom: 3%;
-      border: 0;
-
-      &:hover {
-        cursor: pointer;
-      }
-    }
-
-    &__icon {
-      flex: 1;
-      right: 0;
-      top: .7em;
-      height: 1.3em;
-      color: $c-header-foreground;
-
-      &--small {
-        width: .8em;
-        height: .8em;
-      }
-
-      &--first {
-        left: 0;
-      }
-
-      &:hover {
-        cursor: pointer;
-      }
-    }
-  }
-
-  .home-icon-tablet {
-    display: none;
-  }
-
-  .home-icon {
-    display: initial;
-  }
-
-  @media (min-width: $p-break) {
-    .home-header {
-      &__content {
-        width: $p-width-grid;
-        display: flex;
-        justify-content: space-between;
-      }
-
-      &__home-icon {
-        height: 4em;
-        width: auto;
-        position: relative;
-        left: 0;
-        top: 0;
-      }
-
-      &__icon {
-        position: initial;
-        margin-left: .5em;
-      }
-
-      &__options {
-        height: 100%;
-        display: flex;
-        align-items: center;
-        width: fit-content;
-      }
-    }
-
-    .home-icon-tablet {
-      display: initial;
-    }
-
-    .home-icon {
-      display: none;
-    }
-  }
-
-  @media (min-width: $t-break) {
-    .home-header__content {
-      width: $t-width-grid;
-    }
-
-    .home-icon-tablet {
-      display: none;
-    }
-
-    .home-icon {
-      display: initial;
-    }
-  }
-
-  @media (min-width: $d-break) {
-    .home-header__content {
-      width: $d-width-grid;
-    }
-  }
-
-  @media (min-width: $r-break) {
-    .home-header__content {
-      width: $r-width-grid;
-    }
-  }
-
-  .store-elements-container {
-    display: flex;
-    width: 180px;
-    margin-left: 15px;
-  }
-
-</style>

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -42,6 +42,29 @@
       <p class="mt-5 text-justify text-md">
         {{ product.description }}
       </p>
+      <div class="absolute bottom-0 mb-5">
+        <p class="pb-2 text-xs font-bold uppercase">
+          Escoge tu opción
+        </p>
+        <div
+          class="inline"
+          v-for="(categoryProduct, index) in category.products"
+          :key="index"
+        >
+          <button
+            class="w-8 h-8 mx-1 text-gray-600 border border-gray-400 border-solid rounded-full shadow"
+            :class="{'border-primary' : categoryProduct === product }"
+            @click="$emit('change-slide', index)"
+          >
+            <span
+              class="inline text-xs font-bold text-center"
+              :class="{'text-black' : categoryProduct === product }"
+            >
+              {{ "$".repeat(index + 1) }}
+            </span>
+          </button>
+        </div>
+      </div>
       <button
         class="absolute bottom-0 right-0 px-5 py-2 mb-5 text-sm font-bold text-white rounded-sm bg-primary"
         @click="clickAction"

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -1,32 +1,38 @@
 <template>
   <div
-    class="flex flex-col w-full mx-1 mb-4 bg-white border border-gray-100 border-solid rounded-sm shadow-md"
-    :class="{ 'border-primary' : highlight, 'mt-5' : !highlight }"
+    class="flex flex-row w-full bg-white border border-gray-100 border-solid rounded-md shadow-md product"
   >
     <div
-      class="w-full h-5 text-xs text-left text-white bg-primary"
-      v-if="highlight"
-    >
-      <span class="ml-2">Regalo popular</span>
-    </div>
-    <transition
-      name="fade"
+      class="product__image"
     >
       <img
-        class="object-cover h-20 m-2"
+        class="object-cover w-full h-full"
         :src="product.imageUrl"
         @load="loaded = true;"
         v-show="loaded"
       >
-    </transition>
-    <span class="m-auto text-xl"> {{ product.price | Price }} </span>
-
-    <button
-      class="px-2 py-1 mx-auto my-3 text-xs text-center text-white rounded-sm cursor-pointer bg-primary"
-      @click="goToProduct"
+    </div>
+    <div
+      class="relative flex flex-col w-7/12 mt-3 ml-3 mr-8 product__info"
     >
-      <span class="inline text-center">Ver producto</span>
-    </button>
+      <span class="text-xl font-bold">{{ product.name }}</span>
+      <span
+        class="text-xs text-red-700"
+        :class="{ 'invisible' : !highlight }"
+      >
+        🛍️ Top choice
+      </span>
+
+      <p class="mt-5 text-justify text-md">
+        {{ product.description }}
+      </p>
+      <button
+        class="absolute bottom-0 right-0 px-5 py-2 mb-5 text-sm font-bold text-white rounded-sm bg-primary"
+        @click="goToProduct"
+      >
+        <span class="inline text-center">VER PRODUCTO</span>
+      </button>
+    </div>
   </div>
 </template>
 
@@ -63,3 +69,16 @@ export default {
   },
 };
 </script>
+<style lang="scss">
+  .product {
+    height: 20rem;
+
+    &__image {
+      width: 45%;
+    }
+
+    &__info {
+      width: 55%;
+    }
+  }
+</style>

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -91,6 +91,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    category: {
+      type: Object,
+      default: null,
+    },
   },
   computed: {
     ...mapState([

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -3,8 +3,24 @@
     class="flex flex-row w-full bg-white border border-gray-100 border-solid rounded-md shadow-md product"
   >
     <div
-      class="product__image"
+      class="relative product__image"
     >
+      <div
+        v-if="!hideFavoriteButton"
+        class="absolute top-0 right-0 z-10 flex justify-center p-1 mt-5 mr-5 bg-white rounded-full shadow hover:cursor-pointer"
+        @click="setLikeStatus"
+      >
+        <img
+          v-if="isLiked"
+          class="cursor-pointer"
+          src="../assets/like-color-badge.svg"
+        >
+        <img
+          v-else
+          class="cursor-pointer"
+          src="../assets/like-badge.svg"
+        >
+      </div>
       <img
         class="object-cover w-full h-full"
         :src="product.imageUrl"
@@ -28,7 +44,7 @@
       </p>
       <button
         class="absolute bottom-0 right-0 px-5 py-2 mb-5 text-sm font-bold text-white rounded-sm bg-primary"
-        @click="goToProduct"
+        @click="clickAction"
       >
         <span class="inline text-center">VER PRODUCTO</span>
       </button>
@@ -37,6 +53,7 @@
 </template>
 
 <script>
+import { mapActions, mapState } from 'vuex';
 import convertToClp from '../utils/convert-to-clp';
 
 export default {
@@ -46,8 +63,19 @@ export default {
     };
   },
   methods: {
-    goToProduct() {
+    ...mapActions([
+      'markClicked',
+    ]),
+    clickAction() {
+      this.markClicked(this.product.id);
       window.open(this.product.link, '_blank');
+    },
+    setLikeStatus() {
+      if (this.isLiked) {
+        this.$store.commit('removeFavoriteProduct', this.product.id);
+      } else {
+        this.$store.commit('addFavoriteProduct', this.product);
+      }
     },
   },
   props: {
@@ -58,6 +86,18 @@ export default {
     highlight: {
       type: Boolean,
       default: false,
+    },
+    hideFavoriteButton: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  computed: {
+    ...mapState([
+      'favoriteProducts',
+    ]),
+    isLiked() {
+      return this.product.id in this.favoriteProducts;
     },
   },
   filters: {

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -2,9 +2,14 @@
   <div class="home-container">
     <home-header />
     <div v-if="category">
-      <p class="flex justify-center py-2">
-        Encontramos esto para ti:
-      </p>
+      <div class="py-4 bg-secondary">
+        <p class="flex justify-center text-white">
+          Encontramos:&nbsp; <span class="font-bold">{{ category.name }}</span>
+        </p>
+        <p class="flex justify-center text-sm text-white">
+          {{ category.description }}
+        </p>
+      </div>
       <category
         :category="category"
         v-if="category"

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -14,12 +14,15 @@
         :category="category"
         v-if="category"
       />
-      <div class="button-container">
+      <div class="flex flex-col w-48 pt-10 mx-auto text-gray-700 align-items-center">
+        <p class="pb-3 text-center">
+          No te convence?🤔
+        </p>
         <button
-          class="change-option-button"
+          class="px-1 py-2 text-sm font-bold text-white rounded-sm bg-primary"
           @click="$store.dispatch('getProducts')"
         >
-          O revisa otra opción
+          SIGAMOS BUSCANDO
         </button>
       </div>
     </div>

--- a/app/serializers/category_serializer.rb
+++ b/app/serializers/category_serializer.rb
@@ -3,7 +3,7 @@ class CategorySerializer < ActiveModel::Serializer
 
   def products
     ActiveModel::ArraySerializer.new(
-      object.products.where(status: :approved),
+      object.products.order(:price).where(status: :approved),
       each_serializer: ProductSerializer
     )
   end

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -1,7 +1,8 @@
 class ProductSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
 
-  attributes :id, :name, :price, :store_name, :image_url, :link, :promoted, :average_color
+  attributes :id, :name, :price, :store_name, :image_url, :link,
+             :promoted, :average_color, :description
 
   def store_name
     object.store.name

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,7 @@ module.exports = {
     extend: {
       colors: {
         primary: '#35c6ad',
+        secondary: '#0088D7',
       },
     },
   },


### PR DESCRIPTION
### Contexto

Dado que el objetivo es alcanzar la mayor cantidad de clicks posibles, los usuarios que entran por desktop deben encontrar la página atractiva y debe funcionar bien de modo que puedan navegar cómodamente. La versión mobile que tenemos diseñada se ve mal en desktop, está un poco vacía y genera poco interés visual.

### Qué se está haciendo
- Se agrega la categoría y su descripción al home
- Se rediseñan los componentes product-card, category y home-header (ver imágenes)
- markClicked y setLikeStatus pasan de category a product-card


#### Info adicional
- La vista mobile se ve afectada por este PR, por lo que queda pendiente implementar el nuevo diseño de vista mobile (el mockup está listo en figma).
- Actualmente, el slide central es el "Top Choice" por defecto.
- Los botones de '$' se asignan por el número de índice por ahora. A futuro la cantidad de '$' dependerá del precio.

![Captura de pantalla de 2020-10-07 17-11-13](https://user-images.githubusercontent.com/1688697/95382530-299f9780-08c0-11eb-9e81-c0ec5390e97a.png)

