### PR TITLE
Fix/show categories on favorites

### DIFF
--- a/app/controllers/api/v1/categories_controller.rb
+++ b/app/controllers/api/v1/categories_controller.rb
@@ -9,6 +9,17 @@ class Api::V1::CategoriesController < Api::V1::BaseController
     }
   end
 
+  def show
+    category = Category.find(permitted_params[:id])
+    respond_with category, root: false
+  end
+
+  private
+
+  def permitted_params
+    params.permit(:id)
+  end
+
   def query_params
     params.permit(:page)
   end

--- a/app/javascript/src/api/category.js
+++ b/app/javascript/src/api/category.js
@@ -1,0 +1,12 @@
+import api from './index';
+
+export default {
+  getCategory(categoryId) {
+    const path = `/api/v1/categories/${categoryId}`;
+
+    return api({
+      method: 'get',
+      url: path,
+    });
+  },
+};

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -86,6 +86,7 @@ import { mapState } from 'vuex';
 import category from '../components/category';
 import HomeHeader from '../components/home-header';
 import modal from '../components/modal';
+import categoriesApi from '../api/category.js';
 
 export default {
   name: 'Favorites',

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -114,6 +114,9 @@ export default {
     },
   },
   methods: {
+    openCategory(index) {
+      this.getCategory(this.favoriteProducts[index], index);
+    },
     closeModal() {
       this.modalIsOpen = false;
     },
@@ -124,6 +127,10 @@ export default {
     removeProduct() {
       this.modalIsOpen = false;
       this.$store.commit('removeFavoriteProduct', this.modalProduct);
+    },
+    async getCategory({ categoryId }, index) {
+      this.currentCategory = await categoriesApi.getCategory(categoryId);
+      this.currentCategoryIndex = index;
     },
   },
 };

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -44,15 +44,15 @@
           </div>
           <div class="favorite-product__buttons-container">
             <button
-              v-if="openCategory !== index"
-              @click="openCategory = index"
+              v-if="currentCategoryIndex !== index"
+              @click="openCategory(index)"
               class="favorite-product__button favorite-product__button--left"
             >
               Ver categoría
             </button>
             <button
               v-else
-              @click="openCategory = -1"
+              @click="currentCategoryIndex = -1"
               class="favorite-product__button favorite-product__button--left"
             >
               Ocultar
@@ -67,11 +67,11 @@
         </div>
         <div class="favorite-product__preview">
           <div
-            class="favorite-product__preview-card"
-            :class="{'favorite-product__preview-card--expanded': openCategory === index}"
+            v-if="currentCategoryIndex === index"
+            class="favorite-product__preview-card--expanded"
           >
             <category
-              :category="category"
+              :category="currentCategory"
               :hide-favorite-button="true"
             />
           </div>
@@ -92,7 +92,8 @@ export default {
   name: 'Favorites',
   data() {
     return {
-      openCategory: -1,
+      currentCategoryIndex: -1,
+      currentCategory: null,
       modalProduct: -1,
       modalIsOpen: false,
     };

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -1,8 +1,8 @@
 class ProductSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
 
-  attributes :id, :name, :price, :store_name, :image_url, :link,
-             :promoted, :average_color, :description
+  attributes :id, :name, :price, :store_name, :image_url,
+             :link, :promoted, :average_color, :description, :category_id
 
   def store_name
     object.store.name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       resources :products, only: [:index, :update]
       resources :product_actions, only: [:create]
       resources :stores, only: [:show]
-      resources :categories, only: [:index]
+      resources :categories, only: [:index, :show]
     end
   end
   devise_scope :store do


### PR DESCRIPTION
### Contexto
Al cambiar la lógica de los favoritos para mostrar productos en vez de categorías, se perdió la feature de mostrar la categoría completa dentro de los favoritos, por lo que se requiere que se pueda mostrar nuevamente, en este caso, la categoría a la que corresponde el producto marcado como favorito.

### Qué se está haciendo
- Se agrega el category_id al product_serializer
- Se crea el API endpoint para category show
- Se crean métodos en favorites.vue para obtener la categoría y mostrarla en la vista.
