### PR TITLE
Mobile view

### DIFF
--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -5,7 +5,7 @@
     <div>
       <vueSlickCarousel
         ref="slider"
-        class="w-full mt-8"
+        class="w-full sm:mt-8"
         :arrows="false"
         :center-mode="true"
         :center-padding="0"

--- a/app/javascript/src/components/home-header.vue
+++ b/app/javascript/src/components/home-header.vue
@@ -16,15 +16,11 @@
         <span class="sm:hidden">Vender</span>
       </div>
     </div>
-    <div class="h-full mt-1">
+    <div class="h-full mt-2">
       <router-link to="/">
         <img
-          class="hidden h-12 mx-auto sm:block"
+          class="h-12 mx-auto"
           src="../assets/buenas-ideas.svg"
-        >
-        <img
-          class="mx-auto sm:hidden"
-          src="../assets/buenas-ideas-mini.svg"
         >
       </router-link>
     </div>

--- a/app/javascript/src/components/home-header.vue
+++ b/app/javascript/src/components/home-header.vue
@@ -12,7 +12,8 @@
         class="my-auto ml-1 text-sm"
         @click="goToStore"
       >
-        Vende tus productos
+        <span class="hidden sm:inline">Vende tus productos</span>
+        <span class="sm:hidden">Vender</span>
       </div>
     </div>
     <div class="h-full mt-1">
@@ -30,9 +31,10 @@
     <div class="mr-3 text-right">
       <router-link to="/favorites">
         <button
-          class="h-8 px-3 my-auto text-base border border-solid rounded-sm text-primary border-primary hover:bg-primary hover:text-white"
+          class="h-8 px-3 my-auto text-sm transition-all duration-200 border border-solid rounded-sm text-primary border-primary hover:bg-primary hover:text-white"
         >
-          Ver mis favoritas
+          <span class="hidden sm:inline">Ver mis favoritos</span>
+          <span class="sm:hidden">Favoritos</span>
         </button>
       </router-link>
     </div>

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -27,24 +27,32 @@
         @load="loaded = true;"
         v-show="loaded"
       >
+      <div class="sm:hidden">
+        <div class="absolute top-0 block w-full h-full opacity-50 bg-gradient-to-b from-transparent via-transparent to-black" />
+        <p class="absolute bottom-0 block mx-3 mb-2 text-xl font-bold text-white">
+          {{ product.name }}
+        </p>
+      </div>
     </div>
     <div
-      class="relative flex flex-col w-7/12 mt-3 ml-3 mr-8 product__info"
+      class="relative flex flex-col w-full px-3 mt-1 sm:mt-3 sm:pr-8 sm:h-auto product__info"
     >
-      <span class="text-xl font-bold">{{ product.name }}</span>
-      <span
-        class="text-xs text-red-700"
-        :class="{ 'invisible' : !highlight }"
-      >
-        🛍️ Top choice
-      </span>
+      <div class="h-32">
+        <span class="hidden text-xl font-bold sm:block">{{ product.name }}</span>
+        <span
+          class="text-xs text-red-700"
+          :class="{ 'hidden' : !highlight }"
+        >
+          🛍️ Top choice
+        </span>
 
-      <p class="mt-5 text-justify text-md">
-        {{ product.description }}
-      </p>
-      <div class="absolute bottom-0 mb-5">
-        <p class="pb-2 text-xs font-bold uppercase">
-          Escoge tu opción
+        <p class="min-h-full mt-2 text-sm text-justify sm:mt-3 sm:mr-0 sm:text-base">
+          {{ product.description }}
+        </p>
+      </div>
+      <div class="mb-5 text-center sm:text-left sm:absolute sm:bottom-0">
+        <p class="pb-2 text-sm font-bold tracking-wider uppercase">
+          Escoge tu opción:
         </p>
         <div
           class="inline"
@@ -52,12 +60,12 @@
           :key="index"
         >
           <button
-            class="w-8 h-8 mx-1 text-gray-600 border border-gray-400 border-solid rounded-full shadow"
+            class="w-12 h-12 mx-1 text-gray-600 border border-gray-400 border-solid rounded-full shadow sm:mr-2 sm:ml-0"
             :class="{'border-primary' : categoryProduct === product }"
             @click="$emit('change-slide', index)"
           >
             <span
-              class="inline text-xs font-bold text-center"
+              class="inline text-base font-bold text-center outline-none"
               :class="{'text-black' : categoryProduct === product }"
             >
               {{ "$".repeat(index + 1) }}
@@ -66,7 +74,7 @@
         </div>
       </div>
       <button
-        class="absolute bottom-0 right-0 px-5 py-2 mb-5 text-sm font-bold text-white rounded-sm bg-primary"
+        class="px-5 py-2 mb-6 text-sm font-bold text-white rounded-sm sm:absolute sm:bottom-0 sm:mr-8 sm:right-0 bg-primary place-self-center"
         @click="clickAction"
       >
         <span class="inline text-center">VER PRODUCTO</span>

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -1,9 +1,9 @@
 <template>
   <div
-    class="flex flex-row w-full bg-white border border-gray-100 border-solid rounded-md shadow-md product"
+    class="flex flex-col w-auto mx-auto bg-white border border-gray-100 border-solid rounded-md shadow-md sm:w-full sm:flex-row product"
   >
     <div
-      class="relative product__image"
+      class="relative w-full h-56 product__image sm:h-auto"
     >
       <div
         v-if="!hideFavoriteButton"
@@ -137,15 +137,17 @@ export default {
 };
 </script>
 <style lang="scss">
-  .product {
-    height: 20rem;
+  @media (min-width: 640px) { // sm-breakpoint
+    .product {
+      height: 20rem;
 
-    &__image {
-      width: 45%;
-    }
+      &__image {
+        width: 45%;
+      }
 
-    &__info {
-      width: 55%;
+      &__info {
+        width: 55%;
+      }
     }
   }
 </style>

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -19,7 +19,8 @@
           No te convence?🤔
         </p>
         <button
-          class="px-1 py-2 text-sm font-bold text-white rounded-sm bg-primary"
+          class="px-1 py-2 text-sm font-bold transition-all duration-200 border border-solid rounded-sm text-primary border-primary hover:bg-primary hover:text-white"
+
           @click="$store.dispatch('getProducts')"
         >
           SIGAMOS BUSCANDO

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="home-container">
+  <div class="block w-full min-h-screen text-base bg-background">
     <home-header />
     <div v-if="category">
       <div class="py-4 bg-secondary">
         <p class="flex justify-center text-white">
           Encontramos:&nbsp; <span class="font-bold">{{ category.name }}</span>
         </p>
-        <p class="flex justify-center text-sm text-white">
+        <p class="flex justify-center px-4 text-sm leading-5 text-center text-white">
           {{ category.description }}
         </p>
       </div>
@@ -66,105 +66,11 @@ export default {
 <style lang="scss">
   @import '../../styles/variables';
 
-  .call-text {
-    display: flex;
-    justify-content: center;
-
-    &__category-name {
-      color: $primary-color;
-    }
-  }
-
-  .button-container {
-    display: flex;
-    justify-content: center;
-  }
-
-  .change-option-button {
-    text-align: center;
-    background-color: $primary_color;
-    text-decoration: none;
-    -webkit-appearance: none;
-    height: 2.5em;
-    padding: 5px;
-    color: $white;
-    font-size: 15px;
-    margin-bottom: 3%;
-    border: 0;
-    border-radius: 30.5px;
-
-    &:hover {
-      cursor: pointer;
-    }
-  }
-
-  .home-container {
-    display: block;
-    font-size: $m-font-size;
-    width: 100%;
-    background: $home-background;
-    min-height: 100vh;
-  }
-
-  .home-products-container {
-    justify-content: flex-start;
-    width: $m-width-grid;
-    margin: 3vh auto;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax($m-size-image, 1fr));
-    grid-row-gap: 40px;
-  }
-
   .loader-spinner {
     display: flex;
     justify-content: center;
     height: 42px;
     margin-top: 25px;
-  }
-
-  @media (min-width: $p-break) {
-    .home-container {
-      font-size: $p-font-size;
-
-      .home-products-container {
-        grid-template-columns: repeat(auto-fill, minmax($p-size-image, 1fr));
-        width: $p-width-grid;
-        padding: 0;
-      }
-    }
-  }
-
-  @media (min-width: $t-break) {
-    .home-container {
-      font-size: $t-font-size;
-
-      .home-products-container {
-        grid-template-columns: repeat(auto-fill, minmax($t-size-image, 1fr));
-        width: $t-width-grid;
-      }
-    }
-  }
-
-  @media (min-width: $d-break) {
-    .home-container {
-      font-size: $d-font-size;
-
-      .home-products-container {
-        grid-template-columns: repeat(auto-fill, minmax($d-size-image, 1fr));
-        width: $d-width-grid;
-      }
-    }
-  }
-
-  @media (min-width: $r-break) {
-    .home-container {
-      font-size: $r-font-size;
-
-      .home-products-container {
-        grid-template-columns: repeat(auto-fill, minmax($r-size-image, 1fr));
-        width: $r-width-grid;
-      }
-    }
   }
 
 </style>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
       colors: {
         primary: '#35c6ad',
         secondary: '#0088D7',
+        background: '#f4f8f8',
       },
     },
   },


### PR DESCRIPTION
### Contexto

Una vez implementada la vista desktop, la vista mobile se vio afectada por el nuevo diseño, por lo cual se necesita corregir el nuevo diseño para la vista mobile.

### Qué se está haciendo
- Se agregan clases a elementos, dejando el breakpoint sm de Tailwind (min-width 640px) para la vista desktop, y las clases "normales" para la vista mobile.
- Se reduce el texto del header en mobile.
- Se cambia la distribución de elementos en product-card de flex-row a flex-col
- Se modifica la posición de varios elementos para calzar con la vista mobile
- Se agrandan los botones de opciones en ambas vistas
- Se cambia el relleno del botón de 'Sigamos Buscando' (para destacar 'Ver Producto' como la acción principal)

#### Info adicional
 Queda por corregir la vista favoritos tanto para mobile como desktop, por lo que se hará un PR aparte para esto junto con otras mejoras generales.

<img src="https://user-images.githubusercontent.com/1688697/96152904-6af8fe00-0ee3-11eb-9433-d673bb5ea64c.png" width="300" />
<img src="https://user-images.githubusercontent.com/1688697/96152897-692f3a80-0ee3-11eb-96c4-eea622d173ce.png" width="300" />
