### PR TITLE
Refactor/favorites view

### DIFF
--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -68,7 +68,7 @@
               class="inline text-base font-bold text-center outline-none"
               :class="{'text-black' : categoryProduct === product }"
             >
-              {{ "$".repeat(index + 1) }}
+              {{ categoryProduct.price | toSigns }}
             </span>
           </button>
         </div>

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -86,6 +86,7 @@
 <script>
 import { mapActions, mapState } from 'vuex';
 import convertToClp from '../utils/convert-to-clp';
+import priceToSigns from '../utils/price-to-signs';
 
 export default {
   data() {
@@ -140,6 +141,9 @@ export default {
       const price = convertToClp(value);
 
       return `$${price}`;
+    },
+    toSigns(value) {
+      return priceToSigns(value);
     },
   },
 };

--- a/app/javascript/src/utils/price-to-signs.js
+++ b/app/javascript/src/utils/price-to-signs.js
@@ -1,0 +1,11 @@
+function priceToSigns(value) {
+  if (value < 10000) {
+    return '$';
+  } else if (value < 15000) {
+    return '$$';
+  }
+
+  return '$$$';
+}
+
+export default priceToSigns;

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -44,18 +44,24 @@
               </div>
             </div>
           </div>
-          <div class="favorite-product__buttons-container">
+          <div class="flex flex-row justify-center mb-4 sm:mb-0 sm:flex-col">
+            <button
+              class="px-5 py-1 mx-2 my-1 text-sm font-bold text-white rounded-sm bg-primary"
+              @click="clickAction(product)"
+            >
+              Ver producto
+            </button>
             <button
               v-if="currentCategoryIndex !== index"
               @click="openCategory(index)"
-              class="favorite-product__button favorite-product__button--left"
+              class="px-5 py-1 mx-2 my-1 text-sm font-bold transition-all duration-200 border border-solid rounded-sm text-primary border-primary"
             >
               Ver categoría
             </button>
             <button
               v-else
               @click="currentCategoryIndex = -1"
-              class="favorite-product__button favorite-product__button--left"
+              class="px-5 py-1 mx-2 my-1 text-sm font-bold transition-all duration-200 border border-solid rounded-sm text-primary border-primary"
             >
               Ocultar
             </button>
@@ -78,7 +84,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapActions, mapState } from 'vuex';
 import category from '../components/category';
 import HomeHeader from '../components/home-header';
 import modal from '../components/modal';
@@ -110,6 +116,13 @@ export default {
     },
   },
   methods: {
+    ...mapActions([
+      'markClicked',
+    ]),
+    clickAction(product) {
+      this.markClicked(product.id);
+      window.open(product.link, '_blank');
+    },
     openCategory(index) {
       this.getCategory(this.favoriteProducts[index], index);
     },

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full min-h-screen bg-background">
+  <div class="w-full min-h-screen text-base bg-background">
     <home-header />
     <modal
       :show-modal="modalIsOpen"
@@ -16,13 +16,14 @@
         Mejor no
       </template>
     </modal>
-    <div class="favorite-products">
+    <div class="flex flex-col w-full mx-auto my-4 rounded sm:my-10 sm:shadow-md sm:bg-white bg-background favorite-products ">
       <div v-if="Object.keys(favoriteProducts).length === 0">
         No tienes ningún producto favorito 😢
       </div>
       <div
         v-for="(product, index) in favoriteProducts"
         :key="index"
+        class="w-auto px-3 my-3 bg-white rounded shadow-sm sm:px-6 sm:bg-none sm:shadow-none"
       >
         <div
           class="flex flex-col justify-between w-full sm:flex-row"
@@ -33,13 +34,17 @@
               src="../assets/cross.svg"
               @click="openModal(product.id)"
             >
-                class="favorite-product__image"
+            <div class="justify-center flex-none w-32 h-32 mx-5 my-4 sm:mx-6 sm:w-40 sm:h-40">
+              <img
+                class="self-center object-contain h-full min-w-full"
                 :src="product.imageUrl"
               >
             </div>
             <div>
-              <div>{{ product.name | toUpper }}</div>
-              <div class="favorite-product__price">
+              <p class="text-sm sm:text-lg">
+                {{ product.name }}
+              </p>
+              <div class="text-gray-700">
                 ${{ product.price }}
               </div>
             </div>
@@ -150,17 +155,6 @@ export default {
 
   .favorite-products {
     width: calc(min(90%, 700px));
-    display: flex;
-    flex-direction: column;
-    padding: 30px;
-    margin: 10px auto;
-    font-size: 1.2em;
-    color: $product-name-font-color;
-    border: 1px solid rgba(148, 148, 148, .16);
-    box-shadow: 0 2px 6px rgba(148, 148, 148, .24);
-    border-radius: 6px;
-    background-color: #fff;
-    padding-bottom: 40px;
   }
 
   .favorite-product {
@@ -168,77 +162,6 @@ export default {
     flex-direction: row;
     justify-content: space-between;
     width: 100%;
-
-    @media(max-width: 640px) {
-      flex-direction: column;
-    }
-
-    &__image-name-container {
-      display: flex;
-      align-items: center;
-
-      @media(max-width: 640px) {
-        margin-bottom: 10px;
-      }
-    }
-
-    &__buttons-container {
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-
-      @media(max-width: 640px) {
-        flex-direction: row;
-      }
-    }
-
-    &__image-container {
-      display: flex;
-      justify-content: center;
-      width: 150px;
-      height: 150px;
-      margin-right: 20px;
-    }
-
-    &__image {
-      object-fit: scale-down;
-      max-height: 100%;
-      max-width: 100%;
-    }
-
-    &__price {
-      color: #949494;
-      font-size: .8em;
-    }
-
-    &__button {
-      text-align: center;
-      background-color: $primary_color;
-      text-decoration: none;
-      padding: 5px;
-      color: $white;
-      font-size: 15px;
-      margin-bottom: 3%;
-      border: 0;
-
-      &:hover {
-        cursor: pointer;
-      }
-
-      &--red {
-        background-color: $danger_color;
-      }
-
-      @media(max-width: 640px) {
-        &--left {
-          margin-right: 10px;
-        }
-
-        &--right {
-          margin-left: 10px;
-        }
-      }
-    }
 
     &__preview {
       overflow: hidden;

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -25,12 +25,14 @@
         :key="index"
       >
         <div
-          class="favorite-product"
-          :class="{'favorite-product-container--last': index === favoriteProducts.length - 1}"
+          class="flex flex-col justify-between w-full sm:flex-row"
         >
-          <div class="favorite-product__image-name-container">
-            <div class="favorite-product__image-container">
-              <img
+          <div class="flex items-center">
+            <img
+              class="flex-none transition-opacity duration-200 opacity-50 cursor-pointer hover:text-black hover:opacity-100"
+              src="../assets/cross.svg"
+              @click="openModal(product.id)"
+            >
                 class="favorite-product__image"
                 :src="product.imageUrl"
               >
@@ -56,12 +58,6 @@
               class="favorite-product__button favorite-product__button--left"
             >
               Ocultar
-            </button>
-            <button
-              class="favorite-product__button favorite-product__button--red favorite-product__button--right"
-              @click="openModal(product.id)"
-            >
-              Sacar de favoritos
             </button>
           </div>
         </div>

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -94,6 +94,7 @@ import category from '../components/category';
 import HomeHeader from '../components/home-header';
 import modal from '../components/modal';
 import categoriesApi from '../api/category.js';
+import priceToSigns from '../utils/price-to-signs';
 
 export default {
   name: 'Favorites',
@@ -118,6 +119,9 @@ export default {
   filters: {
     toUpper(value) {
       return value.charAt(0).toUpperCase() + value.slice(1);
+    },
+    toSigns(value) {
+      return priceToSigns(value);
     },
   },
   methods: {

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -45,7 +45,7 @@
                 {{ product.name }}
               </p>
               <div class="text-gray-700">
-                ${{ product.price }}
+                {{ product.price | toSigns }}
               </div>
             </div>
           </div>

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="home-container">
+  <div class="w-full min-h-screen bg-background">
     <home-header />
     <modal
       :show-modal="modalIsOpen"


### PR DESCRIPTION
### Contexto

La vista de favoritos había quedado pendiente para mobile y se necesitan algunos cambios de acuerdo a la funcionalidad actual, entre esos, un fix para el home-header en favoritos, ya que se ve más corto. Además, se debe ocultar el precio y reemplazarlo por una cantidad de '$' que representen qué tan caro es el producto.

### Qué se está haciendo
- Se soluciona el ancho del home-header.
- Se agrega el botón de 'Ver producto' como acción principal ('Ver categoría' pasa a ser acción secundaria).
- El botón de 'Sacar de favoritos' se reemplaza por una cruz en el lado izquierdo.
- Se crea una función que convierte el precio en '$' según el intervalo en el que se encuentra.
- Se filtra el precio en favoritos según esta función, y se actualizan los signos '$' en product-card para generarse con esta nueva función.
- Se actualiza el mobile viewport de favorites.

#### Info adicional

Queda pendiente cambiar el componente de 'category' que se despliega con el botón 'Ver Categoría' por uno más acorde a la vista de favoritos.

![Captura del 2020-10-20 a las 12 58 36](https://user-images.githubusercontent.com/1688697/96612501-323a9980-12d4-11eb-81cf-41bd77c19186.png)
![Captura del 2020-10-20 a las 13 00 43](https://user-images.githubusercontent.com/1688697/96612585-4bdbe100-12d4-11eb-9cdd-390a71746f92.png)
