### PR TITLE
Feat/frontend improvements

### DIFF
--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -22,14 +22,18 @@
         >
       </div>
       <img
-        class="object-cover w-full h-full"
+        class="object-cover w-full h-full cursor-pointer"
         :src="product.imageUrl"
         @load="loaded = true;"
         v-show="loaded"
+        @click="clickAction"
       >
       <div class="sm:hidden">
         <div class="absolute top-0 block w-full h-full opacity-50 bg-gradient-to-b from-transparent via-transparent to-black" />
-        <p class="absolute bottom-0 block mx-3 mb-2 text-xl font-bold text-white">
+        <p
+          class="absolute bottom-0 block mx-3 mb-2 text-xl font-bold text-white cursor-pointer"
+          @click="clickAction"
+        >
           {{ product.name }}
         </p>
       </div>
@@ -38,7 +42,12 @@
       class="relative flex flex-col w-full px-3 mt-1 sm:mt-3 sm:pr-8 sm:h-auto product__info"
     >
       <div class="h-32">
-        <span class="hidden text-xl font-bold sm:block">{{ product.name }}</span>
+        <span
+          class="hidden text-xl font-bold cursor-pointer sm:block"
+          @click="clickAction"
+        >
+          {{ product.name }}
+        </span>
         <span
           class="text-xs text-red-700"
           :class="{ 'hidden' : !highlight }"

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -21,7 +21,7 @@
         <button
           class="px-1 py-2 text-sm font-bold transition-all duration-200 border border-solid rounded-sm text-primary border-primary hover:bg-primary hover:text-white"
 
-          @click="$store.dispatch('getProducts')"
+          @click="getAnotherCategory()"
         >
           SIGAMOS BUSCANDO
         </button>
@@ -60,6 +60,15 @@ export default {
     this.$store.dispatch('getProducts').then(() => {
       this.$store.loading = false;
     });
+  },
+  methods: {
+    getAnotherCategory() {
+      this.$store.dispatch('getProducts');
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      });
+    },
   },
 };
 </script>


### PR DESCRIPTION
### Contexto 
De los PRs anteriores quedaron surgieron un par de sugerencias menores que se pueden implementar rápidamente

### Qué se está haciendo
- Se permite ir al producto haciendo click en la imagen (en desktop) o en el nombre del producto (en desktop y mobile).
- Se agrega un scroll-up al buscar una nueva categoría.

#### Info adicional
![Peek 21-10-2020 10-57](https://user-images.githubusercontent.com/1688697/96730182-52c62a80-138c-11eb-8a6e-c3f8aa7f5325.gif)
