### PR TITLE
Highlight most clicked product

### DIFF
--- a/app/controllers/api/v1/product_actions_controller.rb
+++ b/app/controllers/api/v1/product_actions_controller.rb
@@ -1,7 +1,11 @@
 class Api::V1::ProductActionsController < Api::V1::BaseController
   def create
     product_action = save_action(permitted_params[:action_type])
-    save_promoted if permitted_params[:action_type] == 'click'
+    if permitted_params[:action_type] == 'click'
+      save_promoted
+      product = Product.find_by(id: permitted_params[:product_id])
+      product.add_click
+    end
     respond_with product_action
   end
 

--- a/app/controllers/api/v1/product_actions_controller.rb
+++ b/app/controllers/api/v1/product_actions_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::ProductActionsController < Api::V1::BaseController
     if permitted_params[:action_type] == 'click'
       save_promoted
       product = Product.find_by(id: permitted_params[:product_id])
-      product.add_click
+      product&.add_click
     end
     respond_with product_action
   end

--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -22,7 +22,7 @@
         >
           <product-card
             :product="product"
-            v-bind="{ highlight : index === 1 }"
+            v-bind="{ highlight : index === mostClickedIndex }"
             :category="category"
             @change-slide="changeSlide"
           />
@@ -49,6 +49,7 @@ export default {
     return {
       selectedProductIndex: 1,
       products: [],
+      mostClickedIndex: 0,
     };
   },
   methods: {
@@ -57,6 +58,12 @@ export default {
     },
     changeSlide(index) {
       this.$refs.slider.goTo(index);
+    },
+    updateMostClickedIndex() {
+      const products = this.category.products;
+
+      const mostClickedProduct = products.reduce((p, c) => (p.clicks > c.clicks ? p : c));
+      this.mostClickedIndex = products.indexOf(mostClickedProduct);
     },
   },
   props: {

--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -115,4 +115,8 @@ export default {
   .category {
     width: calc(min(100%, 900px));
   }
+
+  .slick-active {
+    z-index: 1;
+  }
 </style>

--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -91,6 +91,13 @@ export default {
       return value.toUpperCase();
     },
   },
+  watch: {
+    category: {
+      deep: true,
+      inmediate: true,
+      handler: 'updateMostClickedIndex',
+    },
+  },
 };
 </script>
 

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -52,7 +52,7 @@
           class="text-xs text-red-700"
           :class="{ 'hidden' : !highlight }"
         >
-          🛍️ Top choice
+          🛍️ Regalo Popular!
         </span>
 
         <p class="min-h-full mt-2 text-sm text-justify sm:mt-3 sm:mr-0 sm:text-base">

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -60,6 +60,11 @@ class Product < ApplicationRecord
     image.attached?
   end
 
+  def add_click
+    clicks = self.clicks + 1
+    update(clicks: clicks)
+  end
+
   private
 
   def hex_value(red, green, blue)

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -2,7 +2,8 @@ class ProductSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
 
   attributes :id, :name, :price, :store_name, :image_url,
-             :link, :promoted, :average_color, :description, :category_id
+             :link, :promoted, :average_color, :description,
+             :category_id, :clicks
 
   def store_name
     object.store.name


### PR DESCRIPTION
### Contexto
Para promover los productos más populares, se debe destacar el producto con más clicks de cada categoría.

### Qué se está haciendo
- Se soluciona un bug en que independiente del producto clickeado, se abría el producto del último slide.
- Se crea el método 'add_click' al modelo product
- Se agrega la llamada a 'add_click' al crear un productAction de tipo 'click'
- Se añade un deep watcher en el componente category que cambia el mostClickedIndex
- Se reemplaza la condición del highlight para coincidir con el mostClickedIndex

#### Info adicional
El highlight ya existía (se marcaba el producto central), la diferencia es que ahora se aplica al producto más clickeado.