### PR TITLE
fix(AA): permit description param on categories

### DIFF
--- a/app/admin/store_categories.rb
+++ b/app/admin/store_categories.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register Category do
   menu parent: I18n.t('activeadmin.titles.stores')
 
-  permit_params :name
+  permit_params :name, :description
 
   filter :name
 


### PR DESCRIPTION
### Contexto
No se podían crear nuevas categorías ya que siempre tomaba vacío el campo 'description'.

### Qué se está haciendo
- Se agrega el parámetro 'description' a permit_params en category de Active Admin