### PR TITLE
Fix/remove average color method

### DIFF
--- a/app/admin/store_products.rb
+++ b/app/admin/store_products.rb
@@ -71,7 +71,6 @@ ActiveAdmin.register Product do
       row :created_at
       row :updated_at
       row :deleted
-      row :average_color
       row :gender
       row :age
       row :novelty

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -33,23 +33,15 @@ class Product < ApplicationRecord
     end
   end
 
-  def set_average_color
-    image = MiniMagick::Image.open(ActiveStorage::Blob.service.path_for(self.image.key))
-    red, blue, green = image.resize("1x1").get_pixels[0][0]
-    update(average_color: hex_value(red, blue, green))
-  end
-
   def attach_image_from_url(url)
     require 'open-uri'
     downloaded_image = open(url)
     filename = File.basename(URI.parse(url).path)
     image.attach(io: downloaded_image, filename: "#{filename}_#{id}.jpg")
-    set_average_color
   end
 
   def update_image(image_param)
     image.attach(image_param)
-    set_average_color
   end
 
   def validate_image

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -2,7 +2,7 @@ class ProductSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
 
   attributes :id, :name, :price, :store_name, :image_url,
-             :link, :promoted, :average_color, :description, :category_id
+             :link, :promoted, :description, :category_id
 
   def store_name
     object.store.name


### PR DESCRIPTION
### Contexto
Al adjuntar imágenes a productos ocurrían errores ligados al método `set_average_color` del modelo Product. Sin embargo, el atributo `average_color` no se estaba usando en ninguna parte del proyecto, además de que el método no estaba cumpliendo su función.

### Qué se está haciendo
- Se eliminan las llamadas al método `set_average_color`
- Se elimina el método `set_average_color`
- Se elimina la columna `average_color` de Active Admin y el mismo atributo del product_serializer

