### PR TITLE
Feat/smart loading

### DIFF
--- a/app/javascript/src/components/category.vue
+++ b/app/javascript/src/components/category.vue
@@ -25,6 +25,7 @@
             v-bind="{ highlight : index === mostClickedIndex }"
             :category="category"
             @change-slide="changeSlide"
+            @loaded-image="loadedImage"
           />
         </div>
       </vueSlickCarousel>
@@ -50,6 +51,7 @@ export default {
       selectedProductIndex: 1,
       products: [],
       mostClickedIndex: 0,
+      loadedImages: 0,
     };
   },
   methods: {
@@ -64,6 +66,13 @@ export default {
 
       const mostClickedProduct = products.reduce((p, c) => (p.clicks > c.clicks ? p : c));
       this.mostClickedIndex = products.indexOf(mostClickedProduct);
+    },
+    loadedImage() {
+      this.loadedImages++;
+      if (this.loadedImages === this.category.products.length) {
+        this.loadedImages = 0;
+        this.$emit('loaded-category');
+      }
     },
   },
   props: {

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -24,8 +24,7 @@
       <img
         class="object-cover w-full h-full cursor-pointer"
         :src="product.imageUrl"
-        @load="loaded = true;"
-        v-show="loaded"
+        @load="$emit('loaded-image')"
         @click="clickAction"
       >
       <div class="sm:hidden">

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -97,11 +97,6 @@ import convertToClp from '../utils/convert-to-clp';
 import priceToSigns from '../utils/price-to-signs';
 
 export default {
-  data() {
-    return {
-      loaded: false,
-    };
-  },
   methods: {
     ...mapActions([
       'markClicked',

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -48,6 +48,11 @@ export default {
     ClipLoader,
     HomeHeader,
   },
+  data() {
+    return {
+      loading: true,
+    };
+  },
   computed: {
     ...mapState([
       'products',

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="block w-full min-h-screen text-base bg-background">
     <home-header />
-    <div v-if="category">
+    <div
+      v-if="category"
+      v-show="!loading"
+    >
       <div class="py-4 bg-secondary">
         <p class="flex justify-center text-white">
           Encontramos:&nbsp; <span class="font-bold">{{ category.name }}</span>
@@ -70,6 +73,7 @@ export default {
   },
   methods: {
     getAnotherCategory() {
+      this.loading = true;
       this.$store.dispatch('getProducts');
       window.scrollTo({
         top: 0,

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -29,7 +29,8 @@
     </div>
     <div class="loader-spinner">
       <clip-loader
-        :loading="this.$store.loading"
+        :loading="loading"
+        v-show="loading"
       />
     </div>
   </div>
@@ -63,7 +64,7 @@ export default {
   mounted() {
     this.$store.commit('setNextPage', 0);
     this.$store.dispatch('getProducts').then(() => {
-      this.$store.loading = false;
+      this.loading = false;
     });
   },
   methods: {

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -13,6 +13,7 @@
       <category
         :category="category"
         v-if="category"
+        @loaded-category="loadedCategory"
       />
       <div class="flex flex-col w-48 pt-10 mx-auto text-gray-700 align-items-center">
         <p class="pb-3 text-center">
@@ -74,6 +75,9 @@ export default {
         top: 0,
         behavior: 'smooth',
       });
+    },
+    loadedCategory() {
+      this.loading = false;
     },
   },
 };


### PR DESCRIPTION
### Contexto

Al cargar una nueva categoría, las imágenes cargan más lento que la información del producto, por lo que en algunos casos esta demora muestra productos con imágenes que no le corresponde. Además, no existe forma de verificar que efectivamente esté cargando al no haber feedback visual.

### Qué se está haciendo

- Al cargar una nueva categoría, se oculta el contenido de la categoría y se muestra un spinner hasta que se carguen todas las imágenes de la categoría.
