### PR TITLE
Fix: Change category slide on category load

### DIFF
--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -14,6 +14,7 @@
         </p>
       </div>
       <category
+        ref="category"
         :category="category"
         v-if="category"
         @loaded-category="loadedCategory"
@@ -74,6 +75,7 @@ export default {
   methods: {
     getAnotherCategory() {
       this.loading = true;
+      this.$refs.category.changeSlide(0);
       this.$store.dispatch('getProducts');
       window.scrollTo({
         top: 0,


### PR DESCRIPTION
### Contexto

Si al cambiar de categoría, estaba seleccionado un producto cuyo índice era mayor a la cantidad de productos de la categoría siguiente, la nueva categoría no carga y desaparece el componente.

### Qué se está haciendo
- Se soluciona el problema cambiando al primer slide de la categoría al cargar la siguiente categoría.