### PR TITLE
Fix/validate email

### DIFF
--- a/app/javascript/stores/components/easy-product-form.vue
+++ b/app/javascript/stores/components/easy-product-form.vue
@@ -171,6 +171,7 @@ export default {
       this.validateName();
       this.validatePrice();
       this.validateLink();
+      this.validateEmail();
       if (Object.keys(this.errors).length === 0) {
         return true;
       }
@@ -204,6 +205,15 @@ export default {
         '(\\#[-a-z\\d_]*)?$', 'i');
       if (!pattern.test(this.link)) {
         this.errors.link = 'El link debe ser válido';
+      }
+    },
+    validateEmail() {
+      const pattern = new RegExp(
+        '\\A[^@\\s]+@[^@\\s]+\\z', 'i');
+      if (this.email === '') {
+        this.errors.email = 'Debes ingresar un correo electrónico';
+      } else if (!pattern.test(this.email)) {
+        this.errors.email = 'El correo electrónico debe ser válido';
       }
     },
     getHtmlClass(baseClass, errorName) {

--- a/app/javascript/stores/components/easy-product-form.vue
+++ b/app/javascript/stores/components/easy-product-form.vue
@@ -80,7 +80,7 @@
             CORREO ELECTRÓNICO
           </div>
           <input
-            type="email"
+            type="text"
             v-model="email"
             :class="getHtmlClass('product-input__box', 'email')"
             name="email"


### PR DESCRIPTION
### Contexto
Al rellenar el form de Agregar Producto, no se estaba validando el field de e-mail, lo que resultaba en error al dejar el campo vacío.

### Qué se está haciendo
- Se crea el método `validateEmail` para validar el campo usando la misma Regex usada por Devise.
- Se reemplaza `type="email"` por `type="text"` en el input de email para evitar la validación de HTML5.