### PR TITLE
fix(easy-product-form): replace \A and \z by ^ and $ on email regexp

### DIFF
--- a/app/javascript/stores/components/easy-product-form.vue
+++ b/app/javascript/stores/components/easy-product-form.vue
@@ -209,7 +209,7 @@ export default {
     },
     validateEmail() {
       const pattern = new RegExp(
-        '\\A[^@\\s]+@[^@\\s]+\\z', 'i');
+        '^[^@\\s]+@[^@\\s]+$', 'i');
       if (this.email === '') {
         this.errors.email = 'Debes ingresar un correo electrónico';
       } else if (!pattern.test(this.email)) {


### PR DESCRIPTION
### Contexto
En el PR anterior se agregó la validación del correo electrónico, pero en la regexp se incluyeron escape characters (usados por devise en ruby) que no están soportados por javascript.

### Qué se está haciendo
- Se cambia `\A` y `\z` por `^` y `$` en la RegExp de validateEmail()