### PR TITLE
Feat/add aa clicks column

### DIFF
--- a/app/admin/store_products.rb
+++ b/app/admin/store_products.rb
@@ -20,6 +20,7 @@ ActiveAdmin.register Product do
     column :price
     column :link
     column :email
+    column :clicks
     column :created_at
     column :status
     actions

--- a/app/admin/store_products.rb
+++ b/app/admin/store_products.rb
@@ -20,9 +20,6 @@ ActiveAdmin.register Product do
     column :price
     column :link
     column :email
-    column :gender
-    column :age
-    column :novelty
     column :created_at
     column :status
     actions


### PR DESCRIPTION
### Contexto
Necesitamos ver los clicks de cada producto sin necesidad de entrar a ver cada producto en active admin, y además hay otras columnas obsoletas que ya no usamos.

### Qué se está haciendo
- Se eliminan las columnas 'gender', 'age' y 'novelty' de products.
- Se agrega la columna 'clicks' a products.