### PR TITLE
Product link and description

### DIFF
--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -123,7 +123,7 @@ export default {
     ]),
     clickAction() {
       this.markClicked(this.product.id);
-      window.open(this.product.link, '_blank');
+      window.open(this.productLink, '_blank');
     },
     setLikeStatus() {
       if (this.isLiked) {
@@ -166,6 +166,9 @@ export default {
     ]),
     isLiked() {
       return this.product.id in this.favoriteProducts;
+    },
+    productLink() {
+      return `${this.product.link}?ref=bazar.sorteoamigosecreto.com`;
     },
   },
   filters: {

--- a/app/javascript/src/views/favorites.vue
+++ b/app/javascript/src/views/favorites.vue
@@ -130,7 +130,7 @@ export default {
     ]),
     clickAction(product) {
       this.markClicked(product.id);
-      window.open(product.link, '_blank');
+      window.open(this.productLink(product), '_blank');
     },
     openCategory(index) {
       this.getCategory(this.favoriteProducts[index], index);
@@ -149,6 +149,9 @@ export default {
     async getCategory({ categoryId }, index) {
       this.currentCategory = await categoriesApi.getCategory(categoryId);
       this.currentCategoryIndex = index;
+    },
+    productLink(product) {
+      return `${product.link}?ref=bazar.amigosecreto.com`;
     },
   },
 };

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -6,10 +6,10 @@
       v-show="!loading"
     >
       <div class="py-4 bg-secondary">
-        <p class="flex justify-center text-white">
+        <p class="flex justify-center mb-4 text-3xl text-white">
           Encontramos:&nbsp; <span class="font-bold">{{ category.name }}</span>
         </p>
-        <p class="flex justify-center px-4 text-sm leading-5 text-center text-white">
+        <p class="flex justify-center px-4 text-lg font-light leading-5 text-center text-white">
           {{ category.description }}
         </p>
       </div>


### PR DESCRIPTION
Se hacen dos cambios:

- Se agrega un `?ref=bazar.sorteoamigosecreto.com` al hacer la redirección para ver un producto. La idea es que lo vean en sus analytics (no sirve sin hacerlo a mano, porque la redirección no es un link, se hace con un window.location).
- Se agranda el texto con el nombre de la categoría y la descripción de los productos, para que se note más:

![imagen](https://user-images.githubusercontent.com/26608673/100792164-ff1e1680-33f8-11eb-8d6e-97dbfba96cf2.png)

