### PR TITLE
Fix/save last seen category

### DIFF
--- a/app/javascript/src/store/index.js
+++ b/app/javascript/src/store/index.js
@@ -8,7 +8,10 @@ Vue.use(Vuex);
 
 const vuexLocal = new VuexPersistence({
   storage: window.localStorage,
-  reducer: (state) => ({ favoriteProducts: state.favoriteProducts }),
+  reducer: (state) => ({
+    favoriteProducts: state.favoriteProducts,
+    nextPage: state.nextPage,
+  }),
 });
 
 // eslint-disable-next-line new-cap

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -50,7 +50,6 @@ export default {
     ]),
   },
   mounted() {
-    this.$store.commit('setNextPage', 0);
     this.$store.dispatch('getProducts').then(() => {
       this.setLoading(false);
     });


### PR DESCRIPTION
### Contexto
Al recargar la app, se volvía a ver las mismas categorías en el mismo orden, dado que no se renueva la seed al recargar, ni se guarda la última categoría.

### Qué se está haciendo
- Se guarda el nextPage (que indica la siguiente categoría) en VuexPersistance
- Se elimina el commit de setNextPage = 0 que estaba en el mounted() del vista home, para evitar que vuelva al principio.