### PR TITLE
Add web styles

### DIFF
--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -90,7 +90,7 @@
         </div>
         <div class="flex flex-col w-full mt-5 mb-3 text-xs sm:mb-0 sm:flex-row">
           <button
-            class="w-full px-3 py-3 mb-2 font-bold text-white rounded-l-sm gtm sm:mb-0 sm:w-1/2 bg-primary place-self-center"
+            class="w-full px-3 py-3 mb-2 font-bold text-white rounded-l-sm gtm sm:mb-0 sm:mr-1 sm:w-1/2 bg-primary place-self-center"
             @click="clickAction"
           >
             <span class="text-center">🎁 QUIERO VER ESTE REGALO</span>

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -5,7 +5,7 @@
       v-if="category"
       v-show="!loading"
     >
-      <div class="py-4 bg-secondary">
+      <div class="py-4 bg-secondary m-auto category-header">
         <p class="flex justify-center mb-4 text-3xl text-white">
           Encontramos:&nbsp; <span class="font-bold">{{ category.name }}</span>
         </p>
@@ -73,6 +73,10 @@ export default {
     justify-content: center;
     height: 42px;
     margin-top: 25px;
+  }
+
+  .category-header {
+    width: calc(min(100%, 900px));
   }
 
 </style>


### PR DESCRIPTION
En este PR de gifting se implementan dos mejoras en la vista de los productos

1.- se deja el header del tamaño de la tarjeta 
2.- se añade un espacio entre los botones 

Antes:

![Captura de pantalla 2020-12-14 a la(s) 17 37 44](https://user-images.githubusercontent.com/37182412/102133450-e1f33a00-3e33-11eb-873b-bc4afdd3e923.png)


Después:

![Captura de pantalla 2020-12-14 a la(s) 17 36 18](https://user-images.githubusercontent.com/37182412/102133462-e586c100-3e33-11eb-93ef-a24f5a793264.png)
