### PR TITLE
Modify mobile category header style

### DIFF
--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -5,11 +5,12 @@
       v-if="category"
       v-show="!loading"
     >
-      <div class="py-4 bg-secondary m-auto category-header">
-        <p class="flex justify-center mb-4 text-3xl text-white">
-          Encontramos:&nbsp; <span class="font-bold">{{ category.name }}</span>
+      <div class="py-4 sm:bg-secondary bg-white m-auto category-header">
+        <p class="flex justify-center text-2xl text-gray-800 sm:mb-4 sm:text-3xl sm:text-white">
+          <span class="hidden sm:flex">Encontramos:&nbsp; </span>
+          <span class="font-bold">{{ category.name }}</span>
         </p>
-        <p class="flex justify-center px-4 text-lg font-light leading-5 text-center text-white">
+        <p class="hidden sm:flex justify-center px-4 text-lg font-light leading-5 text-center text-white">
           {{ category.description }}
         </p>
       </div>


### PR DESCRIPTION
Este PR de gifting es para modificar el header de las categorías de los productos.
Antes el header era más ancho lo que hacía que los usuarios tuvieran que scrollear la página hacia abajo para encontrar los botones y además era azul, lo que podía hacer que lo confundieran con un botón.

Ahora se sacó la descripción del header para hacerlo más pequeño, se sacó la palabra "encontramos" y se cambiaron los colores.

Antes:

![Captura de pantalla 2020-12-15 a la(s) 11 18 00](https://user-images.githubusercontent.com/37182412/102232174-8f665c00-3ecd-11eb-90a0-da3c81d5836a.png)


Después:

![Captura de pantalla 2020-12-15 a la(s) 11 11 22](https://user-images.githubusercontent.com/37182412/102232198-93927980-3ecd-11eb-81d8-cf247d8177d3.png)


