### PR TITLE
Feat/share product button

### DIFF
--- a/app/controllers/api/v1/product_share_controller.rb
+++ b/app/controllers/api/v1/product_share_controller.rb
@@ -1,0 +1,23 @@
+class Api::V1::ProductShareController < Api::V1::BaseController
+  def create
+    product_share_email
+  end
+
+  def product_share_email
+    ProductMailer
+      .with(
+        to_email: share_params[:to_email],
+        product_link: share_params[:product_link],
+        product_name: share_params[:product_name],
+        product_price: share_params[:product_price]
+      )
+      .share_email
+      .deliver_later
+  end
+
+  private
+
+  def share_params
+    params.permit(:product_name, :product_price, :product_link, :to_email)
+  end
+end

--- a/app/javascript/src/api/products.js
+++ b/app/javascript/src/api/products.js
@@ -22,4 +22,18 @@ export default {
       },
     });
   },
+  shareByEmail(name, price, link, email) {
+    const path = '/api/v1/product_share/';
+
+    return api({
+      method: 'post',
+      url: path,
+      data: {
+        product_name: name,
+        product_price: price,
+        product_link: link,
+        to_email: email,
+      },
+    });
+  },
 };

--- a/app/javascript/src/components/modal-share-email.vue
+++ b/app/javascript/src/components/modal-share-email.vue
@@ -1,0 +1,67 @@
+<template>
+  <div
+    class="fixed top-0 left-0 flex items-center justify-center w-full h-full transition-all duration-300 ease-in-out"
+    :class="{ 'opacity-0': !showModal, 'opacity-100': showModal, 'closed-modal': !showModal, 'z-30': showModal }"
+  >
+    <div
+      @click="close"
+      class="absolute w-full h-full bg-gray-900 opacity-50"
+    />
+    <div class="z-30 w-11/12 mx-auto overflow-y-auto bg-white rounded shadow-lg md:max-w-md">
+      <div class="px-6 py-4 text-left">
+        <div class="flex items-center justify-between pb-3">
+          <div class="text-4xl font-bold">
+            <h3>
+              <slot name="title" />
+            </h3>
+          </div>
+          <div
+            @click="close"
+            class="cursor-pointer"
+          >
+            <img
+              :src="require('assets/images/cross.svg')"
+              alt="close-modal-cross"
+            >
+          </div>
+        </div>
+
+        <slot name="body" />
+
+        <div class="flex justify-end pt-2">
+          <button
+            @click="accept"
+            class="w-full px-3 py-3 mb-2 font-bold text-white rounded-l-sm gtm sm:mb-0 sm:mr-1 sm:w-1/2 bg-primary place-self-center"
+          >
+            <slot name="accept-button-text" />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+  .closed-modal {
+    z-index: -1;
+  }
+</style>
+
+<script>
+export default {
+  props: {
+    showModal: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  methods: {
+    accept() {
+      this.$emit('accept');
+    },
+    close() {
+      this.$emit('close');
+    },
+  },
+};
+</script>

--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -43,6 +43,7 @@
         <p class="my-2 text-sm text-justify sm:mt-3 sm:mr-0 sm:text-base">
           {{ product.description }}
         </p>
+
         <button
           class="px-2 py-1 text-sm text-red-700 border border-red-700 border-solid rounded-sm gtm"
           @click="setLikeStatus"
@@ -62,6 +63,12 @@
             width="18"
           >
           <span>{{ isLiked ? "Guardado!" : "Guardar" }}</span>
+        </button>
+        <button
+          class="px-2 py-1 text-sm text-red-700 border border-red-700 border-solid rounded-sm gtm"
+          @click="openModal"
+        >
+          <span>Compartir!</span>
         </button>
       </div>
       <div class="mt-5 text-center sm:mt-0 sm:w-full sm:text-left">
@@ -134,6 +141,10 @@ export default {
         this.$store.commit('addFavoriteProduct', this.product);
         this.setAnimateFavorites(true);
       }
+    },
+    openModal() {
+      this.$store.commit('setSharedProduct', this.product);
+      this.$store.commit('toggleEmailModal');
     },
     getAnotherCategory() {
       this.$store.commit('addIdeasSearched');

--- a/app/javascript/src/store/index.js
+++ b/app/javascript/src/store/index.js
@@ -27,13 +27,25 @@ const store = new Vuex.Store({
     favoriteProducts: {},
     animateFavorites: false,
     ideasSearched: 0,
+    emailModalIsOpen: false,
+    sharedProduct: null,
+    userEmail: '',
   },
   mutations: {
+    setUserEmail: (state, payload) => {
+      state.userEmail = payload;
+    },
     setCategory: (state, payload) => {
       state.category = payload;
     },
     setNextPage: (state, payload) => {
       state.nextPage = payload;
+    },
+    toggleEmailModal: (state) => {
+      state.emailModalIsOpen = !state.emailModalIsOpen;
+    },
+    setSharedProduct: (state, payload) => {
+      state.sharedProduct = payload;
     },
     addFavoriteProduct: (state, payload) => {
       Vue.set(state.favoriteProducts, payload.id, payload);

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -1,6 +1,26 @@
 <template>
   <div class="block w-full min-h-screen text-base bg-background">
     <home-header />
+    <modal
+      :show-modal="emailModalIsOpen"
+      @accept="productShareByEmail(sharedProduct)"
+      @close="closeModal"
+    >
+      <template #title>
+        Ingresa tu correo para compartir este regalo!
+      </template>
+      <template #body>
+        <input
+          v-model="email"
+          placeholder="example@platan.us"
+          type="email"
+          class="px-2 py-2 h-10 leading-normal block w-full text-gray-800 bg-white font-sans rounded-lg text-left border border-black focus:border-blue-500"
+        >
+      </template>
+      <template #accept-button-text>
+        ENVIAR
+      </template>
+    </modal>
     <div
       v-if="category"
       v-show="!loading"
@@ -32,15 +52,23 @@
 <script>
 import ClipLoader from 'vue-spinner/src/ClipLoader.vue';
 import { mapState, mapMutations } from 'vuex';
+import modal from '../components/modal-share-email.vue';
 import category from '../components/category';
 import HomeHeader from '../components/home-header';
+import productsApi from '../api/products';
 
 export default {
   name: 'HomeView',
+  data() {
+    return {
+      email: '',
+    };
+  },
   components: {
     category,
     ClipLoader,
     HomeHeader,
+    modal,
   },
   computed: {
     ...mapState([
@@ -48,6 +76,9 @@ export default {
       'category',
       'likes',
       'loading',
+      'emailModalIsOpen',
+      'sharedProduct',
+      'userEmail',
     ]),
   },
   mounted() {
@@ -58,9 +89,22 @@ export default {
   methods: {
     ...mapMutations([
       'setLoading',
+      'toggleEmailModal',
+      'setUserEmail',
     ]),
     loadedCategory() {
       this.setLoading(false);
+    },
+    closeModal() {
+      this.toggleEmailModal();
+    },
+    productShareByEmail(product) {
+      this.setUserEmail(this.email);
+      productsApi.shareByEmail(product.name, product.price, this.productLink(product), this.email);
+      this.toggleEmailModal();
+    },
+    productLink(product) {
+      return `${product.link}?ref=bazar.sorteoamigosecreto.com`;
     },
   },
 };

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   scope path: '/api' do
     api_version(module: "Api::V1", path: { value: "v1" }, defaults: { format: 'json' }) do
       resources :products, only: [:index]
+      resources :product_share, only: [:create]
       resources :product_actions, only: [:create]
       resources :stores, only: [:show]
       resources :categories, only: [:index, :show]


### PR DESCRIPTION
**Contexto**

Gifting es el bazar de buenas ideas de sorteoamigosecreto. Intenta ayudar a personas a encontrar "regalos universales no tan pencas". Actualmente las personas pueden revisar todas las categorías disponibles. Para que las categorías no se repitan cada vez que alguien se mete a la página, van apareciendo en un orden al azar. Esto trae un problema: si me meto, y una idea o regalo me gustó, volver a la página y encontrarla de nuevo más tarde puede ser muy tedioso (tendría que buscar hasta que vuelva a aparecer). En el pitch actual se esta trabajando en un botón que permita compartir el producto vía mail (deseable WhatsApp).

**Qué se esta haciendo**


Se agrega un botón para compartir el producto vía mail. El botón abre un modal que permite al usuario ingresar su email y confirmar el envío. Dicha confirmación envía un request a un endpoint, el cual ejecuta el mailer en el backend. 

---
**Info adicional**

El correo del usuario queda guardado, lo cual permite prellenar el email en caso de que el usuario desee seguir compartiendo productos.

![Screen Shot 2021-04-22 at 17 02 29](https://user-images.githubusercontent.com/16639270/115785659-c1149580-a38d-11eb-9b1f-c116c826aff9.png)

![Screen Shot 2021-04-22 at 17 09 19](https://user-images.githubusercontent.com/16639270/115785718-d38ecf00-a38d-11eb-85f6-2e3f87540a89.png)

![Screen Shot 2021-04-22 at 17 10 53](https://user-images.githubusercontent.com/16639270/115785753-ddb0cd80-a38d-11eb-95c1-059ea8e6c079.png)

