### PR TITLE
test(share-mailer): add test for mailler and controller

### DIFF
--- a/app/controllers/api/v1/product_share_controller.rb
+++ b/app/controllers/api/v1/product_share_controller.rb
@@ -1,15 +1,18 @@
 class Api::V1::ProductShareController < Api::V1::BaseController
   def create
-    product_share_email
+    product_share = save_share
+    send_product_share_email if create_params[:platform] == "email"
+
+    respond_with product_share
   end
 
-  def product_share_email
+  def send_product_share_email
     ProductMailer
       .with(
         to_email: share_params[:to_email],
         product_link: share_params[:product_link],
-        product_name: share_params[:product_name],
-        product_price: share_params[:product_price]
+        product_name: product.name,
+        product_price: product.price
       )
       .share_email
       .deliver_later
@@ -17,7 +20,23 @@ class Api::V1::ProductShareController < Api::V1::BaseController
 
   private
 
+  def save_share
+    ProductShare.create!(
+      product_id: create_params[:product_id],
+      platform: create_params[:platform],
+      to_email: share_params[:to_email]
+    )
+  end
+
   def share_params
-    params.permit(:product_name, :product_price, :product_link, :to_email)
+    params.permit(:product_link, :to_email)
+  end
+
+  def create_params
+    params.require(:product_share).permit(:product_id, :platform)
+  end
+
+  def product
+    @product ||= Product.find_by(id: create_params[:product_id])
   end
 end

--- a/app/javascript/src/api/products.js
+++ b/app/javascript/src/api/products.js
@@ -22,17 +22,17 @@ export default {
       },
     });
   },
-  shareByEmail(name, price, link, email) {
-    const path = '/api/v1/product_share/';
+  shareByEmail(payload, email, link) {
+    const path = '/api/v1/product_share';
 
     return api({
       method: 'post',
       url: path,
       data: {
-        product_name: name,
-        product_price: price,
+        product_id: payload,
         product_link: link,
         to_email: email,
+        platform: 'email',
       },
     });
   },

--- a/app/javascript/src/views/home.vue
+++ b/app/javascript/src/views/home.vue
@@ -100,7 +100,7 @@ export default {
     },
     productShareByEmail(product) {
       this.setUserEmail(this.email);
-      productsApi.shareByEmail(product.name, product.price, this.productLink(product), this.email);
+      productsApi.shareByEmail(product.id, this.userEmail, this.productLink(product));
       this.toggleEmailModal();
     },
     productLink(product) {

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,6 +7,7 @@ class Product < ApplicationRecord
   belongs_to :store
   belongs_to :category, optional: true
   has_many :product_actions, dependent: :destroy
+  has_many :product_share, dependent: :destroy
 
   validates :name, presence: true, length: { minimum: 5 }
   validates :price, presence: true, numericality: { greater_than_or_equal_to: 1 }
@@ -77,11 +78,9 @@ end
 #  price         :float
 #  clicks        :integer          default(0)
 #  link          :string
-#  clicks_cost   :float
 #  store_id      :bigint(8)
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  promoted      :boolean          default(FALSE)
 #  deleted       :boolean          default(FALSE)
 #  average_color :text             default("#000000")
 #  gender        :integer          default("either")

--- a/app/models/product_share.rb
+++ b/app/models/product_share.rb
@@ -1,0 +1,36 @@
+class ProductShare < ApplicationRecord
+  include PowerTypes::Observable
+  belongs_to :product
+  enum platform: { email: 0, whatsapp: 1 }
+
+  validates :platform, presence: true
+  with_options if: :shared_with_email? do |shared_by_email|
+    shared_by_email.validates :to_email, presence: true, format: Devise::email_regexp
+  end
+
+  delegate :store, to: :product
+
+  def shared_with_email?
+    platform == 'email'
+  end
+end
+
+# == Schema Information
+#
+# Table name: product_shares
+#
+#  id         :bigint(8)        not null, primary key
+#  platform   :bigint(8)
+#  product_id :bigint(8)        not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  to_email   :string
+#
+# Indexes
+#
+#  index_product_shares_on_product_id  (product_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (product_id => products.id)
+#

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -24,11 +24,9 @@ end
 #  reset_password_sent_at :datetime
 #  remember_created_at    :datetime
 #  name                   :string
-#  balance                :float            default(0.0)
 #  region_id              :bigint(8)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
-#  has_enough_balance     :boolean          default(FALSE)
 #
 # Indexes
 #

--- a/db/migrate/20210427143211_create_product_shares.rb
+++ b/db/migrate/20210427143211_create_product_shares.rb
@@ -1,0 +1,10 @@
+class CreateProductShares < ActiveRecord::Migration[6.1]
+  def change
+    create_table :product_shares do |t|
+      t.bigint :platform
+      t.references :product, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210429130736_add_to_email_to_product_share.rb
+++ b/db/migrate/20210429130736_add_to_email_to_product_share.rb
@@ -1,0 +1,5 @@
+class AddToEmailToProductShare < ActiveRecord::Migration[6.1]
+  def change
+    add_column :product_shares, :to_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_13_141709) do
+ActiveRecord::Schema.define(version: 2021_04_29_130736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -93,6 +93,15 @@ ActiveRecord::Schema.define(version: 2021_04_13_141709) do
     t.index ["product_id"], name: "index_product_actions_on_product_id"
   end
 
+  create_table "product_shares", force: :cascade do |t|
+    t.bigint "platform"
+    t.bigint "product_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "to_email"
+    t.index ["product_id"], name: "index_product_shares_on_product_id"
+  end
+
   create_table "products", force: :cascade do |t|
     t.string "name"
     t.float "price"
@@ -150,5 +159,6 @@ ActiveRecord::Schema.define(version: 2021_04_13_141709) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "product_actions", "products"
+  add_foreign_key "product_shares", "products"
   add_foreign_key "products", "stores"
 end

--- a/spec/controllers/api/v1/product_share_controller_spec.rb
+++ b/spec/controllers/api/v1/product_share_controller_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::ProductShareController, type: :controller do
+  describe 'POST #create' do
+    let(:product) { create(:product) }
+    let(:product_share_params) do
+      {
+        product_share: {
+          platform: "email",
+          product_id: product.id
+        },
+        to_email: "example@platan.us",
+        product_link: "platan.us"
+      }
+    end
+    let(:mailer_params) do
+      {
+        to_email: "example@platan.us",
+        product_link: "platan.us",
+        product_name: product.name,
+        product_price: product.price
+      }
+    end
+    let(:product_mailer) do
+      instance_double('ProductMailer', share_email: message_delivery)
+    end
+    let(:message_delivery) do
+      instance_double('ActionMailer::MessageDelivery', deliver_later: nil)
+    end
+
+    before do
+      allow(ProductMailer).to receive(:with).and_return(product_mailer)
+    end
+
+    context 'with valid params' do
+      it 'returns http success' do
+        post :create, format: :json, params: product_share_params
+        expect(response).to have_http_status(:success)
+      end
+    end
+
+    context 'when email was requested' do
+      it 'shares product by email' do
+        post :create, format: :json, params: product_share_params
+        expect(ProductMailer).to have_received(:with).with(mailer_params)
+        expect(product_mailer).to have_received(:share_email)
+        expect(message_delivery).to have_received(:deliver_later)
+      end
+    end
+  end
+end

--- a/spec/factories/product_shares.rb
+++ b/spec/factories/product_shares.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :product_share do
+    platform { "email" }
+    to_email { "example@platan.us" }
+    product
+  end
+end

--- a/spec/mailers/product_mailer_spec.rb
+++ b/spec/mailers/product_mailer_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe ProductMailer, type: :mailer do
+  describe '#share_email' do
+    let(:params) do
+      {
+        to_email: "example@platan.us",
+        product_name: "Chocolatera 2",
+        product_price: 2000.0,
+        product_link: "platan.us"
+      }
+    end
+
+    let(:mail) { described_class.with(params).share_email.deliver_now }
+    let(:from_email) { 'adolfo@platan.us' }
+
+    before do
+      stub_const('ProductMailer::DEFAULT_EMAIL_ADDRESS', from_email)
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject)
+        .to eq("Compartiste el producto: #{params[:product_name]} | Gifting")
+    end
+
+    it 'renders the sender email' do
+      expect(mail.from).to eq([from_email])
+    end
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([params[:to_email]])
+    end
+  end
+end

--- a/spec/models/product_share_spec.rb
+++ b/spec/models/product_share_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe ProductShare, type: :model do
+  subject(:product_share) { create(:product_share, platform: platform) }
+
+  let(:platform) { 'email' }
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:platform) }
+    it { is_expected.to belong_to(:product) }
+
+    context 'when shared by email' do
+      it { is_expected.to validate_presence_of(:to_email) }
+    end
+
+    context 'when shared by whatsapp' do
+      let(:platform) { 'whatsapp' }
+
+      it { is_expected.not_to validate_presence_of(:to_email) }
+    end
+  end
+end


### PR DESCRIPTION
**Contexto**

Gifting es el bazar de buenas ideas de sorteoamigosecreto. Intenta ayudar a personas a encontrar "regalos universales no tan pencas". Actualmente las personas pueden revisar todas las categorías disponibles. Para que las categorías no se repitan cada vez que alguien se mete a la página, van apareciendo en un orden al azar. Esto trae un problema: si me meto, y una idea o regalo me gustó, volver a la página y encontrarla de nuevo más tarde puede ser muy tedioso (tendría que buscar hasta que vuelva a aparecer). En el pitch actual se esta trabajando en un botón que permita compartir el producto vía mail (deseable WhatsApp).

**Qué se esta haciendo**

Se agregan tests en backend para el mailer que permite compartir el producto y el controlador que implementa el endpoint.

---

**Info adicional**

En el mailer `ProductMailer` se testea que al enviar un mail, los parámetros: `subject`, el email de destino `to_email` y  el mail de origen por defecto  `from_email` están correctamente incluidos. Tambien se testea el controllador `ProductShareController` para garantizar que el metodo `create` ejecuta correctamente el mailer cada vez que se realiza un request hacia el endpoint.
 