### PR TITLE
Cleanup Product model

### DIFF
--- a/app/admin/store_products.rb
+++ b/app/admin/store_products.rb
@@ -2,7 +2,7 @@ ActiveAdmin.register Product do
   menu parent: I18n.t('activeadmin.titles.stores')
 
   permit_params :store_id, :name, :category_id, :price, :description,
-                :link, :email, :gender, :age, :novelty, :status
+                :link, :email, :status
 
   filter :name
   filter :store
@@ -68,9 +68,6 @@ ActiveAdmin.register Product do
       row :created_at
       row :updated_at
       row :deleted
-      row :gender
-      row :age
-      row :novelty
       row :status
     end
   end
@@ -85,9 +82,6 @@ ActiveAdmin.register Product do
       f.input :link
       f.input :email
       f.input :image, as: :file, hint: image_hint(f.object.image)
-      f.input :gender
-      f.input :age
-      f.input :novelty
       f.input :status, as: :select, collection: product.aasm.states(permitted: true).map(&:name)
     end
     f.actions

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -14,12 +14,6 @@ class Product < ApplicationRecord
   validates :link, presence: true
   validates :email, presence: true
   validates :description, presence: true
-  validates :novelty,
-    numericality: { greater_than: 0, less_than_or_equal_to: 5 },
-    allow_blank: true
-
-  enum gender: { either: 0, male: 1, female: 2 }
-  enum age: { any: 0, kid: 1, teen: 2, adult: 3 }
 
   aasm column: :status do
     state :awaiting_approval, initial: true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -51,16 +51,6 @@ class Product < ApplicationRecord
     clicks = self.clicks + 1
     update(clicks: clicks)
   end
-
-  private
-
-  def hex_value(red, green, blue)
-    "##{to_hex red}#{to_hex green}#{to_hex blue}"
-  end
-
-  def to_hex(value)
-    value.to_s(16).rjust(2, '0').upcase
-  end
 end
 
 # == Schema Information

--- a/db/migrate/20210503132533_remove_gender_from_products.rb
+++ b/db/migrate/20210503132533_remove_gender_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveGenderFromProducts < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :products, :gender }
+  end
+end

--- a/db/migrate/20210503132855_remove_age_from_products.rb
+++ b/db/migrate/20210503132855_remove_age_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveAgeFromProducts < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :products, :age }
+  end
+end

--- a/db/migrate/20210503132908_remove_average_color_from_products.rb
+++ b/db/migrate/20210503132908_remove_average_color_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveAverageColorFromProducts < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :products, :average_color }
+  end
+end

--- a/db/migrate/20210503132925_remove_novelty_from_products.rb
+++ b/db/migrate/20210503132925_remove_novelty_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveNoveltyFromProducts < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { remove_column :products, :novelty }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_29_130736) do
+ActiveRecord::Schema.define(version: 2021_05_03_132925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,10 +111,6 @@ ActiveRecord::Schema.define(version: 2021_04_29_130736) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "deleted", default: false
-    t.text "average_color", default: "#000000"
-    t.integer "gender", default: 0
-    t.integer "age", default: 0
-    t.integer "novelty"
     t.string "status"
     t.bigint "category_id"
     t.string "email"

--- a/spec/factories/products.rb
+++ b/spec/factories/products.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     email { "MyString" }
     description { "MyText" }
     store
-    novelty { 3 }
     category
     trait :with_image do
       image do


### PR DESCRIPTION
### Qué se está haciendo
Se eliminan las columnas `gender`, `age`, `novelty` y `average_color` de `products`
Se eliminan los métodos privados `to_hex` y `hex_value` que ya no se usaban.