### PR TITLE
Fix auto-annotate

### DIFF
--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -3,6 +3,7 @@ if Rails.env.development?
     # You can override any of these by setting an environment variable of the
     # same name.
     Annotate.set_defaults(
+      'models' => 'true',
       'routes' => 'false',
       'position_in_routes' => 'after',
       'position_in_class' => 'after',


### PR DESCRIPTION
### Contexto
Al actualizarse annotate, dejó de agregar el schema information a los models, tal como indica el [README del repo](https://github.com/ctran/annotate_models#upgrading-to-3x-and-annotate-models-not-working)

### Qué se está haciendo
Se agrega la key `model` al task `auto_annotate_models`, con valor `true`, para que tenga el mismo comportamiento que antes.