### PR TITLE
Add price intervals to products

### DIFF
--- a/app/admin/store_products.rb
+++ b/app/admin/store_products.rb
@@ -2,15 +2,17 @@ ActiveAdmin.register Product do
   menu parent: I18n.t('activeadmin.titles.stores')
 
   permit_params :store_id, :name, :category_id, :price, :description,
-                :link, :email, :status
+                :link, :email, :status, :promoted
 
   filter :name
   filter :store
   filter :category
   filter :price
+  filter :price_interval
   filter :link
   filter :created_at
   filter :status, as: :select
+  filter :promoted
 
   index do
     id_column
@@ -18,11 +20,13 @@ ActiveAdmin.register Product do
     column :name
     column :category
     column :price
+    column :price_interval
     column :link
     column :email
     column :clicks
     column :created_at
     column :status
+    column :promoted
     actions
   end
 
@@ -56,6 +60,7 @@ ActiveAdmin.register Product do
       row :name
       row :category
       row :price
+      row :price_interval
       row :description
       row :clicks
       row :link
@@ -69,6 +74,7 @@ ActiveAdmin.register Product do
       row :updated_at
       row :deleted
       row :status
+      row :promoted
     end
   end
 
@@ -83,6 +89,7 @@ ActiveAdmin.register Product do
       f.input :email
       f.input :image, as: :file, hint: image_hint(f.object.image)
       f.input :status, as: :select, collection: product.aasm.states(permitted: true).map(&:name)
+      f.input :promoted
     end
     f.actions
   end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,6 +3,9 @@ class Product < ApplicationRecord
   include Rails.application.routes.url_helpers
   include AASM
 
+  INTERVAL_LIMITS = ENV.fetch("PRICE_INTERVAL_LIMITS", "5000,10000,15000,20000")
+                       .split(",").map(&:to_i)
+
   has_one_attached :image
   belongs_to :store
   belongs_to :category, optional: true
@@ -14,6 +17,9 @@ class Product < ApplicationRecord
   validates :link, presence: true
   validates :email, presence: true
   validates :description, presence: true
+  validates :price_interval, presence: true
+
+  before_save :update_price_interval
 
   aasm column: :status do
     state :awaiting_approval, initial: true
@@ -50,6 +56,16 @@ class Product < ApplicationRecord
   def add_click
     clicks = self.clicks + 1
     update(clicks: clicks)
+  end
+
+  private
+
+  def update_price_interval
+    index = 0
+    until price <= INTERVAL_LIMITS[index + 1]
+      index += 1
+    end
+    self.price_interval = index
   end
 end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -57,23 +57,21 @@ end
 #
 # Table name: products
 #
-#  id            :bigint(8)        not null, primary key
-#  name          :string
-#  price         :float
-#  clicks        :integer          default(0)
-#  link          :string
-#  store_id      :bigint(8)
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  deleted       :boolean          default(FALSE)
-#  average_color :text             default("#000000")
-#  gender        :integer          default("either")
-#  age           :integer          default("any")
-#  novelty       :integer
-#  status        :string
-#  category_id   :bigint(8)
-#  email         :string
-#  description   :text
+#  id             :bigint(8)        not null, primary key
+#  name           :string
+#  price          :float
+#  clicks         :integer          default(0)
+#  link           :string
+#  store_id       :bigint(8)
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  deleted        :boolean          default(FALSE)
+#  status         :string
+#  category_id    :bigint(8)
+#  email          :string
+#  description    :text
+#  promoted       :boolean          default(FALSE)
+#  price_interval :integer          default(0)
 #
 # Indexes
 #

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -3,7 +3,7 @@ class ProductSerializer < ActiveModel::Serializer
 
   attributes :id, :name, :price, :store_name, :image_url,
              :link, :description, :category_id, :clicks,
-             :reference_url
+             :reference_url, :promoted, :price_interval
 
   def store_name
     object.store.name

--- a/db/migrate/20210505150656_add_promoted_to_product.rb
+++ b/db/migrate/20210505150656_add_promoted_to_product.rb
@@ -1,0 +1,5 @@
+class AddPromotedToProduct < ActiveRecord::Migration[6.1]
+  def change
+    add_column :products, :promoted, :boolean, default: false
+  end
+end

--- a/db/migrate/20210510152120_add_price_interval_to_products.rb
+++ b/db/migrate/20210510152120_add_price_interval_to_products.rb
@@ -1,0 +1,5 @@
+class AddPriceIntervalToProducts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :products, :price_interval, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_03_132925) do
+ActiveRecord::Schema.define(version: 2021_05_10_152120) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,8 @@ ActiveRecord::Schema.define(version: 2021_05_03_132925) do
     t.bigint "category_id"
     t.string "email"
     t.text "description"
+    t.boolean "promoted", default: false
+    t.integer "price_interval", default: 0
     t.index ["category_id"], name: "index_products_on_category_id"
     t.index ["store_id"], name: "index_products_on_store_id"
   end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -34,4 +34,24 @@ RSpec.describe Product, type: :model do
       it { expect(product).to transition_from(:awaiting_approval).to(:rejected).on_event(:reject) }
     end
   end
+
+  describe 'product price interval' do
+    let(:price) { 12000 }
+    let(:product) { build(:product, price: price) }
+
+    context 'when saving product' do
+      it { expect { product.save! }.to change { product.price_interval }.from(0).to(1) }
+    end
+
+    context 'when updating price' do
+      let(:product) { create(:product, price: price) }
+      let(:new_price) { 18000 }
+
+      it { expect(product.price_interval).to eq(1) }
+
+      it { expect { product.update!(price: new_price) }
+        .to change { product.price_interval }.from(1).to(2)
+      }
+    end
+  end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Product, type: :model do
     it { is_expected.to validate_presence_of(:link) }
     it { is_expected.to validate_presence_of(:email) }
     it { is_expected.to validate_presence_of(:description) }
+    it { is_expected.to validate_presence_of(:price_interval) }
   end
 
   describe 'associations' do


### PR DESCRIPTION
### Contexto

Ahora en Gifting se desea tener más de un producto por cada rango de precio, y en cada rango tener un producto destacado.

### Qué se está haciendo

* Se agregan las columnas `price_interval` y `promoted` al modelo `Product`
* Se crea el método `update_price_interval` en `Product` que toma los límites de cada rango de precio para calcular el index que corresponde al rango.
* Se agregan a AA `promoted` y `price_interval` como filters, columns y rows. Al crear o actualizar un producto, se llama a `update_price_interval` para calcular el rango de precios al que corresponde.
* Se agrega `promoted` y `price_interval` al ProductSerializer