### PR TITLE
Show current state on product edit (Active Admin)

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -26,11 +26,11 @@ class Product < ApplicationRecord
     state :approved, :rejected
 
     event :approve do
-      transitions from: [:awaiting_approval, :rejected], to: :approved, guard: :image_attached?
+      transitions from: [:approved, :awaiting_approval, :rejected], to: :approved, guard: :image_attached?
     end
 
     event :reject do
-      transitions from: [:awaiting_approval, :approved], to: :rejected
+      transitions from: [:rejected, :awaiting_approval, :approved], to: :rejected
     end
   end
 


### PR DESCRIPTION
### Contexto
Al editar un producto aprobado en ActiveAdmin, el input no mostraba el estado approved, por lo que al guardarlo quedaba como rejected o awaiting_approval y se debía editar de nuevo para aprobarlo.

### Que se está haciendo
Se permite transicionar desde `approved` hacia `approved`, y de `rejected` hacia `rejected`. Con esto, no cambia la funcionalidad de la columna, y en Active Admin se muestra el estado actual al editar un producto.