### PR TITLE
Simplify home

### DIFF
--- a/app/javascript/src/components/product-card.vue
+++ b/app/javascript/src/components/product-card.vue
@@ -43,119 +43,23 @@
         <p class="my-2 text-sm text-justify sm:mt-3 sm:mr-0 sm:text-base">
           {{ product.description }}
         </p>
-        <p class="my-2 text-sm text-justify sm:mt-3 sm:mr-0 sm:text-base">
-          RECUERDALO!
-        </p>
-        <button
-          class="px-2 py-1 text-sm border border-gray-700 border-solid rounded-sm gtm"
-          @click="openModal"
-        >
-          <img
-            :src="require('assets/images/mail.svg')"
-            class="w-6"
-          >
-        </button>
-        <button
-          class="px-2 py-1 text-sm border border-gray-700 border-solid rounded-sm gtm"
-          @click="whatsappShare"
-        >
-          <img
-            :src="require('assets/images/whatsapp.svg')"
-            class="w-6"
-          >
-        </button>
-      </div>
-      <div class="mt-5 text-center sm:mt-0 sm:w-full sm:text-left">
-        <p class="pb-2 text-sm font-bold tracking-wider uppercase">
-          Escoge tu opción:
-        </p>
-        <div class="flex flex-row justify-center sm:justify-start">
-          <div
-            class="inline"
-            v-for="(storeProduct, index) in store.products"
-            :key="index"
-          >
-            <button
-              class="w-12 h-12 mx-1 text-gray-600 border border-gray-400 border-solid rounded-full shadow gtm sm:mr-2 sm:ml-0"
-              :class="{'border-primary' : storeProduct === product }"
-              @click="$emit('change-slide', index)"
-            >
-              <span
-                class="inline text-base font-bold text-center outline-none"
-                :class="{'text-black' : storeProduct === product }"
-              >
-                {{ storeProduct.priceInterval | toSigns }}
-              </span>
-            </button>
-          </div>
-        </div>
-        <div class="flex flex-col w-full mt-5 mb-3 text-xs sm:mb-0 sm:flex-row">
-          <button
-            class="w-full px-3 py-3 mb-2 font-bold text-white rounded-l-sm gtm sm:mb-0 sm:mr-1 sm:w-1/2 bg-primary place-self-center"
-            @click="clickAction"
-          >
-            <span class="text-center">🎁 QUIERO VER ESTE REGALO</span>
-          </button>
-          <button
-            class="w-full px-3 py-3 font-bold text-white rounded-r-sm gtm sm:w-1/2 bg-secondary place-self-center"
-            @click="getAnotherstore"
-          >
-            <span class="text-center">🔎 SIGAMOS BUSCANDO</span>
-          </button>
-        </div>
       </div>
     </div>
   </div>
 </template>
 
 <script>
-import { mapActions, mapMutations } from 'vuex';
+import { mapActions } from 'vuex';
 import convertToClp from '../utils/convert-to-clp';
 
-const CLICKS_BEFORE_NOTIFICATION = 10;
-
 export default {
-  data() {
-    return {
-      whatsappNumber: process.env.PHONE_NUMBER,
-    };
-  },
   methods: {
     ...mapActions([
       'markClicked',
     ]),
-    ...mapMutations([
-      'setLoading',
-      'toggleEmailModal',
-      'setSharedProduct',
-    ]),
     clickAction() {
       this.markClicked(this.product.id);
       window.open(this.product.referenceUrl, '_blank');
-    },
-    whatsappShare() {
-      window.open(this.whatsappShareLink, '_blank');
-    },
-    openModal() {
-      this.setSharedProduct(this.product);
-      this.toggleEmailModal();
-    },
-    getAnotherstore() {
-      this.$store.commit('addIdeasSearched');
-      this.setLoading(true);
-      this.$store.dispatch('getProducts');
-      if (this.$store.state.ideasSearched === CLICKS_BEFORE_NOTIFICATION) {
-        this.$notify({
-          title: '¿ Aún no encuentras el regalo que buscas ?',
-          message: 'No te preocupes ! tenemos una alternativa para ti',
-          clickableMessage: 'queleregalo.cl →',
-          clickableMessageLink: 'http://queleregalo.cl',
-        });
-      }
-      window.scrollTo({
-        top: 0,
-        behavior: 'smooth',
-      });
     },
   },
   props: {
@@ -172,22 +76,11 @@ export default {
       default: null,
     },
   },
-  computed: {
-    whatsappShareLink() {
-      return `http://wa.me/${this.whatsappNumber}/?text=${this.whatsappShareText}`;
-    },
-    whatsappShareText() {
-      return encodeURI(`Buenas Ideas | Adquiere tu ${this.product.name} visitando: ${this.product.referenceUrl}`);
-    },
-  },
   filters: {
     Price(value) {
       const price = convertToClp(value);
 
       return `$${price}`;
-    },
-    toSigns(value) {
-      return '$'.repeat(value + 1);
     },
   },
 };

--- a/app/javascript/src/components/store-header.vue
+++ b/app/javascript/src/components/store-header.vue
@@ -23,20 +23,27 @@
             >
           </button>
         </div>
+        <button
+          class="mx-4 text-sm text-gf-purple"
+          @click="getProducts"
+        >
+          Buscar en otra tienda
+        </button>
       </div>
       <div class="md:space-x-5 flex justify-between px-3.5 py-1 mt-5 md:mt-6 border-t md:border-t-0">
         <div
-          v-for="(interval, index) in priceIntervals"
+          v-for="(product, index) in products"
           :key="index"
           class="flex-col items-center justify-center w-24 text-sm rounded-lg cursor-pointer md:rounded-2xl md:w-20 md:h-14 md:border md:pt-1"
-          :class="selectedInterval == index ? 'bg-gf-emerald text-white font-semibold md:border-gf-emerald' : 'text-gf-gray font-normal'"
-          @click="setSelectedInterval(index)"
+          :class="selectedIndex == index ?
+            'bg-gf-emerald text-white font-semibold md:border-gf-emerald' : 'text-gf-gray font-normal'"
+          @click="$emit('change-slide', index)"
         >
           <p class="text-center">
             {{ index | toSigns }}
           </p>
           <p class="text-center">
-            {{ interval }}
+            {{ product.price }}
           </p>
         </div>
       </div>
@@ -44,7 +51,7 @@
   </div>
 </template>
 <script>
-import { mapState, mapMutations, mapActions } from 'vuex';
+import { mapActions } from 'vuex';
 
 export default {
   props: {
@@ -52,23 +59,16 @@ export default {
       type: String,
       required: true,
     },
-  },
-  computed: {
-    ...mapState([
-      'selectedInterval',
-    ]),
-    priceIntervals() {
-      // eslint-disable-next-line no-undef
-      const intervals = process.env.PRICE_INTERVAL_LIMITS.split(',');
-      intervals.splice(0, 1);
-
-      return intervals;
+    selectedIndex: {
+      type: Number,
+      required: true,
+    },
+    products: {
+      type: Array,
+      required: true,
     },
   },
   methods: {
-    ...mapMutations([
-      'setSelectedInterval',
-    ]),
     ...mapActions([
       'getProducts',
     ]),

--- a/app/javascript/src/components/store.vue
+++ b/app/javascript/src/components/store.vue
@@ -5,6 +5,9 @@
     <store-header
       :store-name="store.name"
       class="md:shadow-gf-header"
+      @change-slide="changeSlide"
+      :selected-index="selectedProductIndex"
+      :products="store.products"
     />
     <div>
       <vueSlickCarousel
@@ -33,27 +36,6 @@
           />
         </div>
       </vueSlickCarousel>
-    </div>
-    <p
-      class="mt-5 text-xs tracking-wider text-center text-gray-600 uppercase sm:mt-2"
-    >
-      Rango de precios:
-    </p>
-    <div
-      class="w-full p-2 mx-auto mt-5 text-center bg-white shadow sm:mt-2 sm:rounded-full sm:w-2/3"
-    >
-      <p
-        class="range"
-      >
-        <span
-          v-for="i in (priceIntervals.length - 1)"
-          :key="i"
-          class="inline-block ml-5 first:ml-0"
-        >
-          <span class="inline-block w-6 h-6 border border-gray-500 border-solid rounded-full range__circle"> {{ '$'.repeat(i) }}</span>
-          {{ `: ${priceIntervals[i-1]} - ${priceIntervals[i]}` }}
-        </span>
-      </p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
### Contexto
Se está simplificando la vista del home de Gifting. Ahora solamente va a mostrar el header con la información de la tienda y los botones para cambiar de producto y el carrusel con los productos.

### Cambios
- Se elimina todo lo que no tenía relación con el producto en product-card
- Se agrega la funcionalidad de los botones que muestran el precio (y ahora muestran el precio, no una estimación)

![image](https://user-images.githubusercontent.com/57372662/128563876-e03bb64f-3aea-4656-b1c6-a927e4718997.png)
