### PR TITLE
feat(product-stats): add product clicks stats to activeadmin

### DIFF
--- a/app/admin/stores.rb
+++ b/app/admin/stores.rb
@@ -24,4 +24,30 @@ ActiveAdmin.register Store do
     end
     f.actions
   end
+
+  show do
+    attributes_table do
+      row :email
+      row :password
+      row :name
+      row :region_id
+      row :website
+      row :facebook
+      row :instagram
+      row :twitter
+    end
+
+    panel "Reporte de estadísticas general" do
+      attributes_table_for store do
+        row :total_products_clicks
+      end
+    end
+
+    panel "Reporte de estadísticas de productos" do
+      table_for store.products.order(clicks: :desc) do
+        column :name
+        column :clicks
+      end
+    end
+  end
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -12,6 +12,10 @@ class Store < ApplicationRecord
     connection.execute(Arel.sql("SELECT SETSEED(#{seed})"))
     order(Arel.sql('RANDOM()'))
   end
+
+  def total_products_clicks
+    products.sum(:clicks)
+  end
 end
 
 # == Schema Information

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -11,3 +11,5 @@ es-CL:
           awaiting_approval: Esperando aprobación
           approved: Aprobado
           rejected: Rechazado
+      store:
+        total_products_clicks: Clicks a productos


### PR DESCRIPTION
### Contexto
Los usuarios pueden hacer click en el Instagram, Facebook y Twitter de la tienda, así como en los productos. Se quiere lograr poder ver todas esas estadísticas y además poder ver la cantidad de vistas al producto. 

### Qué se esta haciendo
Agregar a ActiveAdmin las estadísticas de clicks en todos los productos de la tienda y además las estadísticaa de click por producto
<img width="1251" alt="Captura de Pantalla 2021-10-18 a la(s) 4 21 51 p  m" src="https://user-images.githubusercontent.com/69872162/137793603-ab2284fb-8bf1-42f7-b78b-9dab5bb2b48f.png">
<img width="1249" alt="Captura de Pantalla 2021-10-18 a la(s) 4 22 05 p  m" src="https://user-images.githubusercontent.com/69872162/137793628-0850bde6-8535-4fe5-aa26-3d34869078f2.png">
 
