### PR TITLE
Feat/social network stats

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
 
   lint:
     docker:
-      - image: circleci/ruby:2.6-node
+      - image: cimg/ruby:2.6-node
         environment:
           BUNDLE_JOBS: 4
           BUNDLE_RETRY: 3

--- a/app/admin/stores.rb
+++ b/app/admin/stores.rb
@@ -40,6 +40,7 @@ ActiveAdmin.register Store do
     panel "Reporte de estadísticas general" do
       attributes_table_for store do
         row :total_products_clicks
+        row :total_products_displays
       end
     end
 

--- a/app/admin/stores.rb
+++ b/app/admin/stores.rb
@@ -41,6 +41,9 @@ ActiveAdmin.register Store do
       attributes_table_for store do
         row :total_products_clicks
         row :total_products_displays
+        row :facebook_clicks
+        row :instagram_clicks
+        row :twitter_clicks
       end
     end
 

--- a/app/controllers/api/v1/stores_controller.rb
+++ b/app/controllers/api/v1/stores_controller.rb
@@ -9,6 +9,11 @@ class Api::V1::StoresController < Api::V1::BaseController
     }
   end
 
+  def add_social_network_click
+    store = Store.find(params[:id])
+    store.add_social_network_click(params[:social_media])
+  end
+
   private
 
   def index_params

--- a/app/javascript/src/api/stores.js
+++ b/app/javascript/src/api/stores.js
@@ -10,4 +10,15 @@ export default {
       url: path,
     });
   },
+  addSocialNetworkClick(storeId, socialMedia) {
+    const path = `/api/v1/stores/${storeId}/add_social_network_click`;
+
+    return api({
+      method: 'post',
+      url: path,
+      data: {
+        social_media: socialMedia,
+      },
+    });
+  },
 };

--- a/app/javascript/src/components/store-header.vue
+++ b/app/javascript/src/components/store-header.vue
@@ -18,6 +18,7 @@
               <a
                 v-if="store.instagram"
                 :href="store.instagram"
+                @click="incrementSocialNetworkClicks('instagram')"
                 target="_blank"
               >
                 <img
@@ -29,6 +30,7 @@
               <a
                 v-if="store.facebook"
                 :href="store.facebook"
+                @click="incrementSocialNetworkClicks('facebook')"
                 target="_blank"
               >
                 <img
@@ -40,6 +42,7 @@
               <a
                 v-if="store.twitter"
                 :href="store.twitter"
+                @click="incrementSocialNetworkClicks('twitter')"
                 target="_blank"
               >
                 <img
@@ -89,6 +92,7 @@
 </template>
 <script>
 import { mapActions } from 'vuex';
+import storesApi from '../api/stores.js';
 
 export default {
   props: {
@@ -109,6 +113,9 @@ export default {
     ...mapActions([
       'getProducts',
     ]),
+    incrementSocialNetworkClicks(socialMedia) {
+      storesApi.addSocialNetworkClick(this.store.id, socialMedia);
+    },
   },
   filters: {
     toSigns(value) {

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -20,6 +20,20 @@ class Store < ApplicationRecord
   def total_products_displays
     products.sum(&:times_displayed)
   end
+
+  def add_social_network_click(social_network)
+    case social_network
+    when 'facebook'
+      facebook_clicks = self.facebook_clicks + 1
+      update(facebook_clicks: facebook_clicks)
+    when 'instagram'
+      instagram_clicks = self.instagram_clicks + 1
+      update(instagram_clicks: instagram_clicks)
+    when 'twitter'
+      twitter_clicks = self.twitter_clicks + 1
+      update(twitter_clicks: twitter_clicks)
+    end
+  end
 end
 
 # == Schema Information
@@ -40,6 +54,9 @@ end
 #  facebook               :string
 #  instagram              :string
 #  twitter                :string
+#  facebook_clicks        :integer          default(0)
+#  instagram_clicks       :integer          default(0)
+#  twitter_clicks         :integer          default(0)
 #
 # Indexes
 #

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -16,6 +16,10 @@ class Store < ApplicationRecord
   def total_products_clicks
     products.sum(:clicks)
   end
+
+  def total_products_displays
+    products.sum(&:times_displayed)
+  end
 end
 
 # == Schema Information

--- a/config/locales/es-CL.yml
+++ b/config/locales/es-CL.yml
@@ -15,4 +15,5 @@ es-CL:
           rejected: Rechazado
       store:
         total_products_clicks: Clicks a productos
+        total_products_displays: Vistas de productos
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,11 @@ Rails.application.routes.draw do
       resources :products, only: [:index]
       resources :product_share, only: [:create]
       resources :product_actions, only: [:create]
-      resources :stores, only: [:index]
+      resources :stores, only: [:index] do
+        member do
+          post 'add_social_network_click'
+        end
+      end
       resources :categories, only: [:index, :show]
     end
   end

--- a/db/migrate/20211101192425_add_social_networks_clicks_to_stores.rb
+++ b/db/migrate/20211101192425_add_social_networks_clicks_to_stores.rb
@@ -1,0 +1,7 @@
+class AddSocialNetworksClicksToStores < ActiveRecord::Migration[6.1]
+  def change
+    add_column :stores, :facebook_clicks, :integer, default: 0
+    add_column :stores, :instagram_clicks, :integer, default: 0
+    add_column :stores, :twitter_clicks, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_06_194956) do
+ActiveRecord::Schema.define(version: 2021_11_01_192425) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -141,6 +141,9 @@ ActiveRecord::Schema.define(version: 2021_08_06_194956) do
     t.string "facebook"
     t.string "instagram"
     t.string "twitter"
+    t.integer "facebook_clicks", default: 0
+    t.integer "instagram_clicks", default: 0
+    t.integer "twitter_clicks", default: 0
     t.index ["email"], name: "index_stores_on_email", unique: true
     t.index ["region_id"], name: "index_stores_on_region_id"
     t.index ["reset_password_token"], name: "index_stores_on_reset_password_token", unique: true


### PR DESCRIPTION
### Contexto
Los usuarios pueden hacer click en el Instagram, Facebook y Twitter de la tienda, así como en los productos. Se quiere lograr poder ver todas esas estadísticas y además poder ver la cantidad de vistas al producto.

### Qué se esta haciendo
- Crear migración y métodos para incrementar  la cantidad de clicks en instagram, fb y twitter
- Crear y exponer api 
- Agregar a ActiveAdmin las estadísticas 

<img width="1251" alt="Captura de Pantalla 2021-11-01 a la(s) 8 53 35 p  m" src="https://user-images.githubusercontent.com/69872162/139757284-31ea5143-fe4a-4486-a372-66672cec7b00.png">

